### PR TITLE
Fixing string length in `CLD2::DetectLanguageSummary`

### DIFF
--- a/src/webinfo/QUWebInfoTree.cpp
+++ b/src/webinfo/QUWebInfoTree.cpp
@@ -192,7 +192,9 @@ void QUWebInfoTree::getCld2Information() {
 	CLD2::Language language3[3];
 	int percent3[3];
 	int text_bytes;
-	CLD2::Language cld2_lang = CLD2::DetectLanguageSummary(_song->lyrics().join("").remove(QChar('~'), Qt::CaseInsensitive).toStdString().c_str(), _song->lyrics().join("").toStdString().length(), false, language3, percent3, &text_bytes, &isReliable);
+	std::string songText = _song->lyrics().join("").remove(QChar('~'), Qt::CaseInsensitive).toStdString();
+
+	CLD2::Language cld2_lang = CLD2::DetectLanguageSummary(songText.c_str(), songText.length();, false, language3, percent3, &text_bytes, &isReliable);
 	
 	if(isReliable) {
 		for(int i = 0; i < 3; ++i) {

--- a/src/webinfo/QUWebInfoTree.cpp
+++ b/src/webinfo/QUWebInfoTree.cpp
@@ -194,7 +194,7 @@ void QUWebInfoTree::getCld2Information() {
 	int text_bytes;
 	std::string songText = _song->lyrics().join("").remove(QChar('~'), Qt::CaseInsensitive).toStdString();
 
-	CLD2::Language cld2_lang = CLD2::DetectLanguageSummary(songText.c_str(), songText.length();, false, language3, percent3, &text_bytes, &isReliable);
+	CLD2::Language cld2_lang = CLD2::DetectLanguageSummary(songText.c_str(), songText.length(), false, language3, percent3, &text_bytes, &isReliable);
 	
 	if(isReliable) {
 		for(int i = 0; i < 3; ++i) {


### PR DESCRIPTION
Since the char `~` is being replaced in the former call but not in the latter,
the string lengths didn't match in some cases and led to an SIGSEV exception.