### PR TITLE
CI: Fix Mac and Linux build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,42 +13,43 @@ environment:
     # Windows
     - ARCH: x64
       COMPILER: msvc2019 #MinGW
-      QTDIR: C:\Qt\6.4.2\msvc2019_64 #C:\Qt\6.4.2\mingw_64
+      QTDIR: C:\Qt\6.5\msvc2019_64 #C:\Qt\6.4.2\mingw_64
     # macOS
     - ARCH: x64
       COMPILER: Clang
+      QTDIR: Qt/6.5/macos
     # Ubuntu
     - ARCH: x64
       COMPILER: GCC
+      QTDIR: Qt/6.6/gcc_64
 
 image:
   # AppVeyor builds are ordered by the image list:
-  - Visual Studio 2019
+  - Visual Studio 2022
   - macos
-  - Ubuntu1804
+  - Ubuntu2004
 
 matrix:
   exclude:
     # Exclude invalid options
-    - image: Visual Studio 2019
+    - image: Visual Studio 2022
       COMPILER: Clang
-    - image: Visual Studio 2019
+    - image: Visual Studio 2022
       COMPILER: GCC
     - image: macos
       COMPILER: msvc2019 #MinGW
     - image: macos
       COMPILER: GCC
-    - image: Ubuntu1804
+    - image: Ubuntu2004
       COMPILER: msvc2019 #MinGW
-    - image: Ubuntu1804
+    - image: Ubuntu2004
       COMPILER: Clang
 
 for:
   # Windows (MinGW)
-  -
-    matrix:
+  - matrix:
       only:
-        - image: Visual Studio 2019
+        - image: Visual Studio 2022
 
     clone_folder: C:\UltraStar-Manager
 
@@ -70,7 +71,7 @@ for:
     before_build:
       - cmd: set PATH=%QTDIR%\bin;C:\Program Files (x86)\NSIS\;%PATH%
       - cmd: echo PATH=%PATH%
-      - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+      - cmd: call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
 
     build_script:
       - cmd: cd C:\UltraStar-Manager
@@ -78,19 +79,19 @@ for:
       #- cmd: qmake audiotag.pro -spec win32-msvc #win32-g++
       #- cmd: nmake #-j %NUMBER_OF_PROCESSORS%
       - cmd: cd ..\cleanup\
-      - cmd: qmake cleanup.pro -spec win32-msvc #win32-g++
+      - cmd: qmake6 cleanup.pro -spec win32-msvc #win32-g++
       - cmd: nmake #-j %NUMBER_OF_PROCESSORS%
       - cmd: cd ..\lyric\
-      - cmd: qmake lyric.pro -spec win32-msvc #win32-g++
+      - cmd: qmake6 lyric.pro -spec win32-msvc #win32-g++
       - cmd: nmake #-j %NUMBER_OF_PROCESSORS%
       - cmd: cd ..\preparatory\
-      - cmd: qmake preparatory.pro -spec win32-msvc #win32-g++
+      - cmd: qmake6 preparatory.pro -spec win32-msvc #win32-g++
       - cmd: nmake #-j %NUMBER_OF_PROCESSORS%
       - cmd: cd ..\rename\
-      - cmd: qmake rename.pro -spec win32-msvc #win32-g++
+      - cmd: qmake6 rename.pro -spec win32-msvc #win32-g++
       - cmd: nmake #-j %NUMBER_OF_PROCESSORS%
       - cmd: cd ..\..\
-      - cmd: qmake UltraStar-Manager.pro -spec win32-msvc #win32-g++
+      - cmd: qmake6 UltraStar-Manager.pro -spec win32-msvc #win32-g++
       - cmd: nmake #-j %NUMBER_OF_PROCESSORS%
 
     after_build:
@@ -108,8 +109,7 @@ for:
       - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
   # Mac
-  -
-    matrix:
+  - matrix:
       only:
         - image: macos
 
@@ -117,7 +117,7 @@ for:
 
     init:
       - sh: echo _NPROCESSORS_ONLN=$(getconf _NPROCESSORS_ONLN)
-      - sh: export PATH=$HOME/Qt/6.4.0/macos/bin:/usr/local/bin:$PATH
+      - sh: export PATH=$HOME/$QTDIR/bin:/usr/local/bin:$PATH
       - sh: set PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig"
 
     install:
@@ -130,22 +130,22 @@ for:
 
     build_script:
       - cd src/plugins/audiotag/
-      - qmake audiotag.pro
+      - qmake6 audiotag.pro
       - make -j$(getconf _NPROCESSORS_ONLN)
       - cd ../cleanup/
-      - qmake cleanup.pro
+      - qmake6 cleanup.pro
       - make -j$(getconf _NPROCESSORS_ONLN)
       - cd ../lyric/
-      - qmake lyric.pro
+      - qmake6 lyric.pro
       - make -j$(getconf _NPROCESSORS_ONLN)
       - cd ../preparatory/
-      - qmake preparatory.pro
+      - qmake6 preparatory.pro
       - make -j$(getconf _NPROCESSORS_ONLN)
       - cd ../rename/
-      - qmake rename.pro
+      - qmake6 rename.pro
       - make -j$(getconf _NPROCESSORS_ONLN)
       - cd ../../
-      - qmake UltraStar-Manager.pro
+      - qmake6 UltraStar-Manager.pro
       - make -j$(getconf _NPROCESSORS_ONLN)
       - cd ../bin/release/
       - ls
@@ -158,16 +158,15 @@ for:
         name: UltraStar-Manager disk image
 
   # Ubuntu (AppImage)
-  -
-    matrix:
+  - matrix:
       only:
-        - image: Ubuntu1804
+        - image: Ubuntu2004
 
     clone_folder: ~/UltraStar-Manager
 
     init:
       - sh: echo _NPROCESSORS_ONLN=$(getconf _NPROCESSORS_ONLN)
-      - sh: export PATH=$HOME/Qt/6.4.2/gcc_64/bin:$PATH
+      - sh: export PATH=$HOME/$QTDIR/bin:$PATH
 
     install:
       - ps: $env:package_version = ("$(git describe --tags --always --long)").trim()
@@ -177,28 +176,28 @@ for:
       # UltraStar-Manager needs these:
       - sh: sudo apt install -y libtag1-dev libcld2-dev libmediainfo-dev
       # linuxdeployqt needs these:
-      - sh: sudo apt install -y libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb-dev libxkbcommon-x11-0 libgtk2.0-dev
+      - sh: sudo apt install -y libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb-dev libxkbcommon-x11-0 libxcb-cursor0 libgtk2.0-dev
       # build qtstyleplugins with gtk2.0
       #- sh: git clone https://code.qt.io/qt/qtstyleplugins.git && cd qtstyleplugins && qmake && make -j$(nproc) && sudo make install && cd -
 
     build_script:
       - sh: cd src/plugins/audiotag/
-      - sh: qmake audiotag.pro
+      - sh: qmake6 audiotag.pro
       - sh: make -j$(getconf _NPROCESSORS_ONLN)
       - sh: cd ../cleanup/
-      - sh: qmake cleanup.pro
+      - sh: qmake6 cleanup.pro
       - sh: make -j$(getconf _NPROCESSORS_ONLN)
       - sh: cd ../lyric/
-      - sh: qmake lyric.pro
+      - sh: qmake6 lyric.pro
       - sh: make -j$(getconf _NPROCESSORS_ONLN)
       - sh: cd ../preparatory/
-      - sh: qmake preparatory.pro
+      - sh: qmake6 preparatory.pro
       - sh: make -j$(getconf _NPROCESSORS_ONLN)
       - sh: cd ../rename/
-      - sh: qmake rename.pro
+      - sh: qmake6 rename.pro
       - sh: make -j$(getconf _NPROCESSORS_ONLN)
       - sh: cd ../../
-      - sh: qmake UltraStar-Manager.pro
+      - sh: qmake6 UltraStar-Manager.pro
       - sh: make -j$(getconf _NPROCESSORS_ONLN)
       - sh: cd ../bin/release/
       # Build AppImage


### PR DESCRIPTION
Fixes the AppVeyor CI build for Linux and MacOS. Also makes the Windows CI "slightly less broken", it still suffers from linkage errors/dependencies not being there though.