### PR TITLE
Windows: install taglib in app folder instead of globally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
           cd taglib
           cmake -B build -G "Visual Studio 17 2022" -A x64 -DWITH_ZLIB=OFF -DBUILD_SHARED_LIBS=ON -DENABLE_STATIC_RUNTIME=OFF -DBUILD_TESTING=OFF
           msbuild build/install.vcxproj -p:Configuration=Release
+          cp -r "C:/Program Files/taglib/include/taglib" ../include
+          copy build/taglib/Release/tag.dll ../lib/win64
+          copy build/taglib/Release/tag.lib ../lib/win64
       - name: Install ZenLib
         run: |
           git clone https://github.com/MediaArea/ZenLib.git

--- a/src/UltraStar-Manager.pro
+++ b/src/UltraStar-Manager.pro
@@ -243,18 +243,17 @@ INCLUDEPATH += . \
 
 win32 {
 	INCLUDEPATH += ../include/cld2/public \
-		"C:/Program Files/taglib/include/taglib" \
+		../include/taglib \
 		"C:/Program Files/MediaInfoLib/include"
 
 	LIBS += -L"../lib/win64" \
-		-lcld2
+		-lcld2 \
+		-ltag
 	LIBS += -L"C:/Program Files/MediaInfoLib/lib" \
 		-lmediainfo \
 		-lzen
 	LIBS += -L"C:/Program Files/zlib/lib" \
 		-lzlib
-	LIBS += -L"C:/Program Files/taglib/lib" \
-		-ltag
 
 	RC_ICONS += UltraStar-Manager.ico
 }


### PR DESCRIPTION
Same as https://github.com/UltraStar-Deluxe/UltraStar-Creator/pull/37

There's currently a problem with the runner on Mac, which I will fix in a separate PR