### PR TITLE
CI: Fix Mac build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
+          brew unlink python@3.12 && brew link --overwrite python@3.12
           brew install qt
           brew install taglib
           brew install libmediainfo


### PR DESCRIPTION
Currently the runner complains about being unable to link python 3.12. No idea why, but this fixes it.