### PR TITLE
Add missing Qt6Multimedia.dll to installer

### DIFF
--- a/setup/win64/UltraStar-Manager.nsi
+++ b/setup/win64/UltraStar-Manager.nsi
@@ -71,6 +71,7 @@ Section "Application" SecCopyUI
 	;;File "Qt6Svg.dll" ;; added via windeployqt, but not needed
 	File "Qt6Widgets.dll"
 	File "Qt6Xml.dll"
+	File "Qt6Multimedia.dll"
 	File "UltraStar-Manager.exe"
 	;;SetOutPath "$INSTDIR\iconengines" ;; added via windeployqt, but not needed
 	;;File "iconengines\qsvgicon.dll" ;; added via windeployqt, but not needed
@@ -328,6 +329,7 @@ Section "Uninstall"
 	;;Delete "$INSTDIR\Qt6Svg.dll"
 	Delete "$INSTDIR\Qt6Widgets.dll"
 	Delete "$INSTDIR\Qt6Xml.dll"
+	Delete "$INSTDIR\Qt6Multimedia.dll"
 	Delete "$INSTDIR\UltraStar-Manager.exe"
 
 	Delete "$INSTDIR\Uninstall.exe"


### PR DESCRIPTION
The Windows installer is currently (and probably has been for a while already) producing a broken install due to a missing Qt library.