### PR TITLE
CI: Build for both Mac on Intel and ARM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,8 +101,12 @@ jobs:
           if-no-files-found: error
 
   build_mac:
-    name: Build for MacOS
-    runs-on: macos-13
+    name: Build for MacOS (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]
+      fail-fast: false
 
     steps:
       - name: Get Number of CPU Cores
@@ -112,6 +116,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Determine Arch
+        run: |
+          if [ "${{ matrix.os }}" = "macos-13" ]; then
+            echo "arch=x86" >> $GITHUB_ENV
+          else
+            echo "arch=ARM" >> $GITHUB_ENV
+          fi
       - name: Install Dependencies
         run: |
           brew unlink python@3.12 && brew link --overwrite python@3.12
@@ -128,6 +139,20 @@ jobs:
           export CFLAGS="-Wno-narrowing -O3"
           ./compile_libs.sh
           cp libcld2.dylib ../../../lib/MacOS
+      - name: Fix Qt lib rpaths # see: https://github.com/orgs/Homebrew/discussions/2823#discussioncomment-2010340)
+        run: |
+          install_name_tool -id '@rpath/QtCore.framework/Versions/A/QtCore' $(brew --prefix)/lib/QtCore.framework/Versions/A/QtCore
+          install_name_tool -id '@rpath/QtGui.framework/Versions/A/QtGui' $(brew --prefix)/lib/QtGui.framework/Versions/A/QtGui
+          install_name_tool -id '@rpath/QtNetwork.framework/Versions/A/QtNetwork' $(brew --prefix)/lib/QtNetwork.framework/Versions/A/QtNetwork
+          install_name_tool -id '@rpath/QtWidgets.framework/Versions/A/QtWidgets' $(brew --prefix)/lib/QtWidgets.framework/Versions/A/QtWidgets
+          install_name_tool -id '@rpath/QtPdf.framework/Versions/A/QtPdf' $(brew --prefix)/lib/QtPdf.framework/Versions/A/QtPdf
+          install_name_tool -id '@rpath/QtSvg.framework/Versions/A/QtSvg' $(brew --prefix)/lib/QtSvg.framework/Versions/A/QtSvg
+          install_name_tool -id '@rpath/QtVirtualKeyboard.framework/Versions/A/QtVirtualKeyboard' $(brew --prefix)/lib/QtVirtualKeyboard.framework/Versions/A/QtVirtualKeyboard
+          install_name_tool -id '@rpath/QtQuick.framework/Versions/A/QtQuick' $(brew --prefix)/lib/QtQuick.framework/Versions/A/QtQuick
+          install_name_tool -id '@rpath/QtQmlModels.framework/Versions/A/QtQmlModels' $(brew --prefix)/lib/QtQmlModels.framework/Versions/A/QtQmlModels
+          install_name_tool -id '@rpath/QtQml.framework/Versions/A/QtQml' $(brew --prefix)/lib/QtQml.framework/Versions/A/QtQml
+          install_name_tool -id '@rpath/QtOpenGL.framework/Versions/A/QtOpenGL' $(brew --prefix)/lib/QtOpenGL.framework/Versions/A/QtOpenGL
+          install_name_tool -id '@rpath/QtMultimedia.framework/Versions/A/QtMultimedia' $(brew --prefix)/lib/QtMultimedia.framework/Versions/A/QtMultimedia
       - name: Build plugins
         run: |
           cd src/plugins/audiotag/
@@ -151,18 +176,18 @@ jobs:
           qmake6 UltraStar-Manager.pro
           make -j$${{ steps.cpu-cores.outputs.count }}
           cd ../bin/release
-          mv UltraStar-Manager.dmg MAC-UltraStar-Manager.dmg
+          mv UltraStar-Manager.dmg MAC-${{ env.arch }}-UltraStar-Manager.dmg
       - name: Upload Portable Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MAC-UltraStar-Manager-portable
+          name: MAC-${{ env.arch }}-UltraStar-Manager-portable
           path: bin/release
           if-no-files-found: error
       - name: Upload Image Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MAC-UltraStar-Manager-image
-          path: bin/release/MAC-UltraStar-Manager.dmg
+          name: MAC-${{ env.arch }}-UltraStar-Manager-image
+          path: bin/release/MAC-${{ env.arch }}-UltraStar-Manager.dmg
           if-no-files-found: error
 
   build_linux:
@@ -240,12 +265,13 @@ jobs:
           pattern: "*"
       - name: Prepare Artifacts
         run: |
-          zip -r MAC-UltraStar-Manager-portable.zip MAC-UltraStar-Manager-portable
+          zip -r MAC-x86-UltraStar-Manager-portable.zip MAC-x86-UltraStar-Manager-portable
+          zip -r MAC-ARM-UltraStar-Manager-portable.zip MAC-ARM-UltraStar-Manager-portable
           zip -r WIN64-UltraStar-Manager-portable.zip WIN64-UltraStar-Manager-portable
           mv WIN64-UltraStar-Manager-installer/UltraStar-Manager* WIN64-UltraStar-Manager-installer/WIN64-UltraStar-Manager-setup.exe
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "LINUX-UltraStar-Manager-appimage/*, MAC-UltraStar-Manager-image/*, MAC-UltraStar-Manager-portable.zip, WIN64-UltraStar-Manager-installer/*, WIN64-UltraStar-Manager-portable.zip"
+          artifacts: "LINUX-UltraStar-Manager-appimage/*, MAC-x86-UltraStar-Manager-image/*, MAC-x86-UltraStar-Manager-portable.zip, MAC-ARM-UltraStar-Manager-image/*, MAC-ARM-UltraStar-Manager-portable.zip, WIN64-UltraStar-Manager-installer/*, WIN64-UltraStar-Manager-portable.zip"
           draft: true
           artifactErrorsFailBuild: true

--- a/src/UltraStar-Manager.pro
+++ b/src/UltraStar-Manager.pro
@@ -342,6 +342,9 @@ macx {
 	# Run macdeployqt to bundle the required Qt libraries with the application
 	QMAKE_POST_LINK += macdeployqt ../bin/release/UltraStar-Manager.app -libpath=../lib/MacOS -always-overwrite -verbose=3 $$escape_expand(\\n\\t)
 
+	# Add Ad-Hoc code signature to allow ARM Macs to run it
+	QMAKE_POST_LINK += codesign --force --deep --sign - --preserve-metadata=entitlements,requirements,flags,runtime ../bin/release/UltraStar-Manager.app $$escape_expand(\\n\\t)
+
 	# Create a fancy Mac disk image
 	QMAKE_POST_LINK += create-dmg --volname UltraStar-Manager --volicon resources/UltraStar-Manager.icns --app-drop-link 350 170 --background ../setup/macx/img/UltraStar-Manager_bg.png --hide-extension UltraStar-Manager.app --window-size 500 300 --text-size 14 --icon-size 64 --icon UltraStar-Manager.app 150 170 --no-internet-enable --skip-jenkins "../bin/release/UltraStar-Manager.dmg" ../bin/release/UltraStar-Manager.app/
 }


### PR DESCRIPTION
This also adds the `install_tool_name` fix for the Qt libraries we added for the Creator a while back.
A friend has confirmed that this runs on their M2 mac.