### PR TITLE
Fix Font Color of Directory Files

### DIFF
--- a/src/songtree/QUSongItem.cpp
+++ b/src/songtree/QUSongItem.cpp
@@ -37,7 +37,7 @@ QUSongItem::QUSongItem(QUSongFile *song, bool isToplevel):
 void QUSongItem::clearContents() {
 	for(int i = 0; i < this->columnCount(); ++i) {
 		this->setIcon(i, QIcon());
-		this->setForeground(i, Qt::white);
+		this->setForeground(i, Qt::black);
 		this->setToolTip(i, "");
 		this->setBackground(i, QColor(0, 0, 0, 0));
 	}


### PR DESCRIPTION
The file entries in the song tree have white font, which results in poor contrast with the background, making it very difficult to read the text. See #48.

This was changed in https://github.com/UltraStar-Deluxe/UltraStar-Manager/commit/040404a15b55b048835a0dcb02a57cd2fa41a899. I'm guessing this was just a typo, and it was not meant to change the color of the text (judging by the other changes in the commit).

Fixes #48

