### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,10 +135,15 @@ jobs:
           else
             echo "arch=ARM" >> $GITHUB_ENV
           fi
-      - name: Install Dependencies
+      - name: Install Dependencies # macos-13 needs to install old Qt bottle due to break introduced by https://github.com/Homebrew/homebrew-core/commit/ec5bed9bbcaee87f26208ddb39da93c15722ffad
         run: |
           brew unlink python@3.12 && brew link --overwrite python@3.12
-          brew install qt
+          if [ "${{ matrix.os }}" = "macos-13" ]; then
+            curl -L -H "Authorization: Bearer QQ==" -o qt-6.7.3.ventura.bottle.1.tar.gz https://ghcr.io/v2/homebrew/core/qt/blobs/sha256:5a16728c19d459550d2f369498f431a164569a727475298a53fea542bfaddf77
+            brew install -f qt-6.7.3.ventura.bottle.1.tar.gz
+          else
+            brew install qt
+          fi
           brew install taglib
           brew install libmediainfo
           brew install libebur128
@@ -221,6 +226,8 @@ jobs:
         with:
           version: "6.5.*"
           modules: qtmultimedia
+      - name: Remove libunwind # workaround for libunwind conflicts on Ubuntu 22.04, see https://github.com/actions/runner-images/issues/9546
+        run: sudo apt remove libunwind-*
       - name: Install Dependencies
         run: |
           sudo apt update -qq


### PR DESCRIPTION
This PR fixes the CI for the macOS x86 and Linux builds.

The macOS x86 build was failing due to an issue caused by https://github.com/Homebrew/homebrew-core/commit/ec5bed9bbcaee87f26208ddb39da93c15722ffad. Apparently, there was a build issue with QtWebKit, and the solution was to disable QtWebKit if the Xcode version is less than 15.3. QtPDF is only built if QtWebKit is enabled. So, even though the Manager doesn't use QtWebKit, it's still impacted by that issue. My proposed solution is to manually download and install the old Qt 6.7.3 bottle from before the problematic commit was introduced, which includes the needed QtPDf framework.

The Linux build issue is caused by conflicts between the pre-installed `libunwind` and the one needed by GStreamer. This can be worked around by simply uninstalling the pre-installed `libunwind` per https://github.com/actions/runner-images/issues/9546#issuecomment-2014940361

The Linux build still fails due to the new code introduced in #59. The Ubuntu 22.04 runner is using a very outdated TagLib release from 2016, and I used a function call that was not available in that old version. I will submit a separate PR to fix that.