### PR TITLE
Don't include DMG in macOS Portable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: MAC-${{ env.arch }}-UltraStar-Manager-portable
-          path: bin/release
+          path: |
+            bin/release
+            !bin/release/*.dmg
           if-no-files-found: error
       - name: Upload Image Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The macOS portable also includes the .dmg file, which is not needed and significantly increases the size of the package.