### PR TITLE
Build Plugins Automatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,31 +68,14 @@ jobs:
           lib /out:cld2.lib *.obj
           copy cld2.lib ../../../lib/win64
           copy cld2.dll ../../../lib/win64
-      - name: Build plugins
-        run: |
-          cd src/plugins/audiotag/
-          qmake audiotag.pro -spec win32-msvc
-          nmake
-          cd ../cleanup
-          qmake6 cleanup.pro -spec win32-msvc
-          nmake
-          cd ../lyric
-          qmake6 lyric.pro -spec win32-msvc
-          nmake
-          cd ../preparatory
-          qmake6 preparatory.pro -spec win32-msvc
-          nmake
-          cd ../rename
-          qmake6 rename.pro -spec win32-msvc
-          nmake
       - name: Build UltraStar-Manager
         run: |
+          mkdir bin/release
           cp "C:/Program Files/taglib/bin/tag.dll" bin/release/
           cp "C:/Program Files/zlib/bin/zlib.dll" bin/release/
           cp lib/win64/ebur128.dll bin/release/
           cp lib/win64/cld2.dll bin/release/
-          cd src
-          qmake6 UltraStar-Manager.pro -spec win32-msvc
+          qmake6 -r -spec win32-msvc
           nmake
       - name: Create installer
         uses: joncloud/makensis-action@v4.1
@@ -171,29 +154,11 @@ jobs:
           install_name_tool -id '@rpath/QtQml.framework/Versions/A/QtQml' $(brew --prefix)/lib/QtQml.framework/Versions/A/QtQml
           install_name_tool -id '@rpath/QtOpenGL.framework/Versions/A/QtOpenGL' $(brew --prefix)/lib/QtOpenGL.framework/Versions/A/QtOpenGL
           install_name_tool -id '@rpath/QtMultimedia.framework/Versions/A/QtMultimedia' $(brew --prefix)/lib/QtMultimedia.framework/Versions/A/QtMultimedia
-      - name: Build plugins
-        run: |
-          cd src/plugins/audiotag/
-          qmake6 audiotag.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../cleanup/
-          qmake6 cleanup.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../lyric/
-          qmake6 lyric.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../preparatory/
-          qmake6 preparatory.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../rename/
-          qmake6 rename.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
       - name: Build UltraStar-Manager
         run: |
-          cd src
-          qmake6 UltraStar-Manager.pro
+          qmake6
           make -j$${{ steps.cpu-cores.outputs.count }}
-          cd ../bin/release
+          cd bin/release
           mv UltraStar-Manager.dmg MAC-${{ env.arch }}-UltraStar-Manager.dmg
       - name: Upload Portable Artifact
         uses: actions/upload-artifact@v4
@@ -236,27 +201,9 @@ jobs:
           sudo apt install -y libgl1-mesa-dev build-essential libpulse-mainloop-glib0 libgstreamer-plugins-base1.0-dev
           sudo apt install -y libtag1-dev libcld2-dev libmediainfo-dev libebur128-dev
           sudo apt install -y libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb-dev libxkbcommon-x11-0 libxcb-cursor0 libgtk2.0-dev libfuse2
-      - name: Build plugins
-        run: |
-          cd src/plugins/audiotag/
-          qmake6 audiotag.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../cleanup/
-          qmake6 cleanup.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../lyric/
-          qmake6 lyric.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../preparatory/
-          qmake6 preparatory.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
-          cd ../rename/
-          qmake6 rename.pro
-          make -j${{ steps.cpu-cores.outputs.count }}
       - name: Build UltraStar-Manager
         run: |
-          cd src
-          qmake6 UltraStar-Manager.pro
+          qmake6
           make -j${{ steps.cpu-cores.outputs.count }}
       - name: Create AppImage
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ src/tmp
 src/*.autosave
 src/ui
 Makefile
+Makefile.*
 ui
 release
 *.rc

--- a/README.md
+++ b/README.md
@@ -52,15 +52,11 @@ This allows passing a certain folder as song path to UltraStar-Manager, convenie
    Select (recommended)
    * Qt -> Qt 6.5 -> MSVC 2019
    * Qt -> Developer and Designer Tools -> MSVC 2019
-3. Open and compile all task plugins (except albumartexchange, amazon and freecovers)
-   * open respective *.pro files in subdirectory src\plugins with Qt Creator
+3. Open and compile UltraStar-Manager
+   * open `all.pro` with Qt Creator
    * disable shadow build in Project tab
    * build
-4. Open and compile UltraStar-Manager
-   * open UltraStar-Manager.pro in subdirectory src with Qt Creator
-   * disable shadow build in Project tab
-   * build
-5. Manage your entire song collection with ease!
+4. Manage your entire song collection with ease!
 
 #### Compiling on Linux
 (under construction)
@@ -68,18 +64,10 @@ This allows passing a certain folder as song path to UltraStar-Manager, convenie
 1. Install the Qt framework: `sudo apt-get install qt6-base-dev qt6-multimedia-dev`
 2. Install dependencies: `sudo apt-get install libtag1-dev libcld2-dev libmediainfo-dev libebur128-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb-dev libxkbcommon-x11-0 libxcb-cursor0 libgtk2.0-dev`
 3. Clone repository: `git clone https://github.com/UltraStar-Deluxe/UltraStar-Manager && cd UltraStar-Manager`
-4. Compile UltraStar-Manager plugins
-   * from command line
-     * audiotag plugin: `cd src/plugins/audiotag && qmake6 audiotag.pro && make && cd ../../../`
-     * cleanup plugin: `cd src/plugins/cleanup && qmake6 cleanup.pro && make && cd ../../../`
-     * lyrics plugin: `cd src/plugins/lyric && qmake6 lyric.pro && make && cd ../../../`
-     * preparatory plugin: `cd src/plugins/preparatory && qmake6 preparatory.pro && make && cd ../../../`
-     * rename plugin: `cd src/plugins/rename && qmake6 rename.pro && make && cd ../../../`
-   * using Qt Creator: open the respective *.pro files in Qt Creator, disable shadow build in Project tab, then build   
-5. Compile UltraStar-Manager
-   * from command line: `cd src && qmake6 UltraStar-Manager.pro && make && cd ../` (Note: if "make" fails with "stdlib.h was not found", open makefile and remove "-isystem /usr/include " from it. Afterwards, run "make" again.)
-   * using Qt Creator: open UltraStar-Manager.pro in Qt Creator, disable shadow build in Project tab, then build and run
-6. Run UltraStar Manager: `bin/release/UltraStar-Manager` and manage your entire song collection with ease!
+4. Compile UltraStar-Manager
+   * from command line: `qmake6 && make` (Note: if "make" fails with "stdlib.h was not found", open makefile and remove "-isystem /usr/include " from it. Afterwards, run "make" again.)
+   * using Qt Creator: open `all.pro` in Qt Creator, disable shadow build in Project tab, then build and run
+5. Run UltraStar Manager: `bin/release/UltraStar-Manager` and manage your entire song collection with ease!
 
 #### Compiling on Mac OS X
 (under construction)
@@ -87,17 +75,9 @@ This allows passing a certain folder as song path to UltraStar-Manager, convenie
 1. Install homebrew via `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 2. Install the Qt framework via `brew install qt`.
 3. Install external dependencies via `brew install taglib mediainfo libebur128`
-4. Compile UltraStar-Manager plugins
-   * from command line
-     * audiotag plugin: `cd src/plugins/audiotag && qmake6 audiotag.pro && make`
-     * cleanup plugin: `cd src/plugins/cleanup && qmake6 cleanup.pro && make`
-     * lyrics plugin: `cd src/plugins/lyric && qmake6 lyric.pro && make`
-     * preparatory plugin: `cd src/plugins/preparatory && qmake6 preparatory.pro && make`
-     * rename plugin: `cd src/plugins/rename && qmake6 rename.pro && make`
-   * using Qt Creator: open the respective *.pro files in Qt Creator, disable shadow build in Project tab, then build
 4. Compile UltraStar-Manager
-   * from command line: `cd src && qmake6 UltraStar-Manager.pro && make`
-   * using Qt Creator: open UltraStar-Manager.pro in Qt Creator, disable shadow build in Project tab, then build and run
+   * from command line: `qmake6 && make`
+   * using Qt Creator: open `all.pro` in Qt Creator, disable shadow build in Project tab, then build and run
 5. Manage your entire song collection with ease!
 
 ### 6. Contribute

--- a/all.pro
+++ b/all.pro
@@ -1,0 +1,11 @@
+  TEMPLATE = subdirs
+ 
+  SUBDIRS = \
+            src/plugins/audiotag \
+            src/plugins/cleanup \
+            src/plugins/lyric \
+            src/plugins/preparatory \
+            src/plugins/rename \
+            src
+
+  src.file = src/UltraStar-Manager.pro


### PR DESCRIPTION
The current build process requires the user to manually `cd` into the directories of each plugin, which is very tedious. It also makes development more challenging, because the generated Makefiles are disconnected. The developer has to manually keep track of which files changed and remember to execute the corresponding Makefile.

This PR adds a new project file `all.pro` in the root project directory which automatically calls all the others, solving this problem. All you have to do to build the entire project is `qmake6 && make`

The CI script and build instructions are updated to use the new build method. Adding this file does not break the old build method, so there should not be any downstream impact (i.e. to packagers).