### PR TITLE
Support More Audio Formats by Default

### DIFF
--- a/src/QUSongSupport.cpp
+++ b/src/QUSongSupport.cpp
@@ -97,7 +97,7 @@ QStringList QUSongSupport::allowedScoreFiles() {
 }
 
 QStringList QUSongSupport::allowedAudioFiles() {
-	return registryKey("allowedAudioFiles", "*.mp3 *.ogg *.m4a *.avi *.divx *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpg *.ogm *.ts *.vob *.webm *.wmv *.3gp");
+	return registryKey("allowedAudioFiles", "*.mp3 *.ogg *.m4a *.avi *.divx *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpg *.ogm *.ts *.vob *.webm *.wmv *.3gp *.opus *.flac");
 }
 
 QStringList QUSongSupport::allowedImageFiles() {


### PR DESCRIPTION
The Manager does not support the audio formats Opus and FLAC by default. This PR changes that.

This change will only impact *new* installations. The reason is because the Manager stores this string as a setting in the `QSettings` location (varies by platform), and the default string in the source code is only used as a fallback if the setting does not exist, i.e. when it is a new installation.

So users with existing installations will still need to manually edit the Windows registry or config file if they want support for these formats. It might be worth revisiting how the Manager handles supported file formats in a future PR.