### PR TITLE
Update Release Action to ubuntu-latest image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,7 +244,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     name: Draft a Release
     needs: [build_windows, build_mac, build_linux]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts from Build Jobs
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The release action queues, but does not get picked up by a runner. The release action currently uses the `ubuntu-20.04` image, which has been removed by GitHub. This PR switches it to `ubuntu-latest`, which fixes the problem and will prevent it from occurring again in the future.