### PR TITLE
Improved Line Ending Support

### DIFF
--- a/src/plugins/preparatory/QUPreparatoryTask.cpp
+++ b/src/plugins/preparatory/QUPreparatoryTask.cpp
@@ -1,6 +1,7 @@
 #include "QUPreparatoryTask.h"
 #include "QUSmartCheckBox.h"
 #include "QUSmartInputField.h"
+#include "QUSmartComboBox.h"
 #include "QUSongSupport.h"
 #include "QU.h"
 
@@ -9,6 +10,7 @@
 #include <QSettings>
 #include <QFileInfo>
 #include <QDir>
+#include <algorithm>
 
 QUPreparatoryTask::QUPreparatoryTask(TaskModes mode, QObject *parent):
 	QUSimpleTask(parent),
@@ -73,6 +75,11 @@ QUPreparatoryTask::QUPreparatoryTask(TaskModes mode, QObject *parent):
 		this->setDescription(tr("Add missing ’P1’ and ’P2’ in duets"));
 		this->setToolTip(tr("Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them"));
 		break;
+	case FixLineEndings:
+		this->setIcon(QIcon(":/types/text.png"));
+		this->setDescription(tr("Fix line endings"));
+		this->setToolTip(tr("Change the .txt line endings to either CRLF or LF"));
+		break;
 	}
 }
 
@@ -121,6 +128,9 @@ void QUPreparatoryTask::startOn(QUSongInterface *song) {
 	case AddMissingDuetTags:
 		addMissingDuetTags(song);
 		break;
+	case FixLineEndings:
+		fixLineEndings(song);
+		break;
 	}
 }
 
@@ -154,6 +164,9 @@ QList<QUSmartSettingInterface*> QUPreparatoryTask::smartSettings() const {
 			break;
 		case SetGenreIfEmpty:
 			_smartSettings.append(new QUSmartInputField("preparatory/setGenreIfEmpty_genre", "None", new QRegularExpressionValidator(QRegularExpression(".*"), nullptr), tr("Genre:"), ""));
+			break;
+		case FixLineEndings:
+			_smartSettings.append(new QUSmartComboBox("preparatory/fixLineEndings_lineEnding", tr("Convert to:"), {"CRLF", "LF"}, std::clamp(settings.value("preparatory/fixLineEndings_lineEnding", 0).toInt(), 0, 1)));
 			break;
 		}
 	}
@@ -457,4 +470,9 @@ void QUPreparatoryTask::addMissingDuetTags(QUSongInterface *song) {
 	}
 
 	//song->log(tr("Missing ’P1’ and ’P2’ added to \"%1 - %2\".").arg(song->artist()).arg(song->title()), QU::Information);
+}
+
+void QUPreparatoryTask::fixLineEndings(QUSongInterface *song)
+{
+	song->setLineEnding(static_cast<LineEnding>(smartSettings().at(0)->value().toInt()));
 }

--- a/src/plugins/preparatory/QUPreparatoryTask.h
+++ b/src/plugins/preparatory/QUPreparatoryTask.h
@@ -24,7 +24,8 @@ public:
 		SetGenreIfEmpty,
 		FixLanguage,
 		FixApostrophes,
-		AddMissingDuetTags
+		AddMissingDuetTags,
+		FixLineEndings
 	};
 	Q_DECLARE_FLAGS(TaskModes, TaskMode)
 
@@ -49,6 +50,7 @@ private:
 	void fixLanguage(QUSongInterface *song);
 	void fixApostrophes(QUSongInterface *song);
 	void addMissingDuetTags(QUSongInterface *song);
+	void fixLineEndings(QUSongInterface *song);
 };
 
 #endif /*QUPREPARATORYTASK_H_*/

--- a/src/plugins/preparatory/QUPreparatoryTaskFactory.cpp
+++ b/src/plugins/preparatory/QUPreparatoryTaskFactory.cpp
@@ -32,6 +32,7 @@ QList<int> QUPreparatoryTaskFactory::types() const {
 	result << QUPreparatoryTask::FixLanguage;
 	result << QUPreparatoryTask::FixApostrophes;
 	result << QUPreparatoryTask::AddMissingDuetTags;
+	result << QUPreparatoryTask::FixLineEndings;
 	return result;
 }
 

--- a/src/plugins/preparatory/preparatory.de.ts
+++ b/src/plugins/preparatory/preparatory.de.ts
@@ -22,12 +22,12 @@
 <context>
     <name>QUPreparatoryTask</name>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="20"/>
+        <location filename="QUPreparatoryTask.cpp" line="22"/>
         <source>Assign missing files automatically</source>
         <translation>Weise fehlende Dateien automatisch zu</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="29"/>
+        <location filename="QUPreparatoryTask.cpp" line="31"/>
         <source>Fix or remove unsupported tags</source>
         <oldsource>Remove unsupported tags</oldsource>
         <translation>Korrigiere oder entferne nicht unterstützte Tags</translation>
@@ -37,211 +37,226 @@
         <translation type="obsolete">&lt;b&gt;#MP3&lt;/b&gt; ... erste Audiodatei.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... erstes Bild mit dem Muster: &lt;i&gt;[CO]|cove?r?&lt;/i&gt;.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... erstes Bild mit dem Muster: &lt;i&gt;[BG]|back&lt;/i&gt;.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... erstes Video.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="21"/>
+        <location filename="QUPreparatoryTask.cpp" line="23"/>
         <source>&lt;b&gt;#MP3&lt;/b&gt; ... first audio file found.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... first video file found.&lt;br&gt;&lt;br&gt;Does not reset tags that have already been set.</source>
         <translation>&lt;b&gt;#MP3&lt;/b&gt; ... erste Audiodatei.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... erstes Bild mit dem Muster.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... erstes Bild mit dem Muster.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... erstes Video.&lt;br&gt;&lt;br&gt;Es werden keine vorhandenen Tags überschrieben.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="30"/>
+        <location filename="QUPreparatoryTask.cpp" line="32"/>
         <source>Replaces the incorrect &lt;b&gt;#AUTHOR&lt;/b&gt; tag by the correct &lt;b&gt;#CREATOR&lt;/b&gt; tag and deletes all other unsupported tags.</source>
         <translation>Ersetzt den inkorrekten &lt;b&gt;#AUTHOR&lt;/b&gt;-Tag durch den korrekten &lt;b&gt;#CREATOR&lt;/b&gt;-Tag and löscht alle anderen nicht unterstützten Tags.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="34"/>
+        <location filename="QUPreparatoryTask.cpp" line="36"/>
         <source>Fix audio length via #END tag</source>
         <translation>Passe Audio-Länge mittels #END-Tag an</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="35"/>
+        <location filename="QUPreparatoryTask.cpp" line="37"/>
         <source>Sets &lt;b&gt;#END&lt;/b&gt; to the length of the song if audio file present and longer than song. &lt;b&gt;Appends a little time buffer.&lt;/b&gt;</source>
         <translation>Setzt &lt;b&gt;#END&lt;/b&gt; auf die Länge des Songs, sofern eine Audio-Datei existiert, die länger als der Song ist. &lt;b&gt;Beinhaltet einen kleinen Zeitpuffer.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="39"/>
+        <location filename="QUPreparatoryTask.cpp" line="41"/>
         <source>Round #GAP to nearest integer</source>
         <oldsource>Round #GAP to nearest integer.</oldsource>
         <translation>Runde #GAP auf die nächste Ganzzahl</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="43"/>
+        <location filename="QUPreparatoryTask.cpp" line="45"/>
         <source>Capitalize #TITLE tag</source>
         <oldsource>Fix capitalization of #TITLE tag</oldsource>
         <translation>Korrigiere Großschreibung des #TITLE-Tags</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="44"/>
+        <location filename="QUPreparatoryTask.cpp" line="46"/>
         <source>Applies some rules of capitalization to form a consistent appearance for all song titles.&lt;br&gt;&lt;br&gt;&lt;b&gt;Useful for english songs.&lt;/b&gt;</source>
         <translation>Nutzt einige Regeln um die Großschreibung anzupassen, um eine einheitliche Darstellung aller Songtitel zu gewährleisten.&lt;br&gt;&lt;br&gt;&lt;b&gt;Nützlich für englische Songs.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="48"/>
+        <location filename="QUPreparatoryTask.cpp" line="50"/>
         <source>Capitalize #ARTIST tag</source>
         <translation>Korrigiere Großschreibung des #ARTIST-Tags</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="49"/>
+        <location filename="QUPreparatoryTask.cpp" line="51"/>
         <source>Capitalize each word of the artist, e.g. &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</source>
         <translation>Korrigiert die Großschreibung eines jeden Wortes des Interpreten, z.B. &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <location filename="QUPreparatoryTask.cpp" line="55"/>
         <source>Set #EDITION tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <location filename="QUPreparatoryTask.cpp" line="56"/>
         <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <location filename="QUPreparatoryTask.cpp" line="60"/>
         <source>Set #GENRE tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <location filename="QUPreparatoryTask.cpp" line="61"/>
         <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <location filename="QUPreparatoryTask.cpp" line="65"/>
         <source>Fix #LANGUAGE tag to contain English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <location filename="QUPreparatoryTask.cpp" line="66"/>
         <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <location filename="QUPreparatoryTask.cpp" line="70"/>
         <source>Fix apostrophes in song artist and title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <location filename="QUPreparatoryTask.cpp" line="71"/>
         <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <location filename="QUPreparatoryTask.cpp" line="75"/>
         <source>Add missing ’P1’ and ’P2’ in duets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <location filename="QUPreparatoryTask.cpp" line="76"/>
         <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="80"/>
+        <source>Fix line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="81"/>
+        <source>Change the .txt line endings to either CRLF or LF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Pattern:</source>
         <translation>Muster:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
         <source>(cover)</source>
         <translation>(Cover)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>(background)</source>
         <translation>(Hintergrund)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>Buffer:</source>
         <translation>Puffer:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>seconds</source>
         <translation>Sekunden</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="145"/>
+        <location filename="QUPreparatoryTask.cpp" line="155"/>
         <source>Capitalize English songs only</source>
         <translation>Korrigiere die Großschreibung nur von englischen Songs</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="146"/>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
         <source>Capitalize each word</source>
         <translation>Schreibe jeden Wortanfang groß</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="147"/>
-        <location filename="QUPreparatoryTask.cpp" line="150"/>
+        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="160"/>
         <source>Capitalize first word only</source>
         <translation>Schreibe nur den ersten Wortanfang groß</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <location filename="QUPreparatoryTask.cpp" line="163"/>
         <source>Edition:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <location filename="QUPreparatoryTask.cpp" line="166"/>
         <source>Genre:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="195"/>
+        <location filename="QUPreparatoryTask.cpp" line="169"/>
+        <source>Convert to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="208"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>Großschreibung konnte nicht angepasst werden, da der Song nicht englisch ist: &quot;%1 - %2&quot;. Hinweis: Aufgabeneinstellung anpassen.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <location filename="QUPreparatoryTask.cpp" line="216"/>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <location filename="QUPreparatoryTask.cpp" line="294"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <location filename="QUPreparatoryTask.cpp" line="309"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <location filename="QUPreparatoryTask.cpp" line="318"/>
         <source>#EDITION set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <location filename="QUPreparatoryTask.cpp" line="328"/>
         <source>#GENRE set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <location filename="QUPreparatoryTask.cpp" line="392"/>
         <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <location filename="QUPreparatoryTask.cpp" line="408"/>
         <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <location filename="QUPreparatoryTask.cpp" line="437"/>
         <source>Line: %1, Note: %2, Diff: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <location filename="QUPreparatoryTask.cpp" line="444"/>
         <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <location filename="QUPreparatoryTask.cpp" line="469"/>
         <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/plugins/preparatory/preparatory.es.ts
+++ b/src/plugins/preparatory/preparatory.es.ts
@@ -22,222 +22,237 @@
 <context>
     <name>QUPreparatoryTask</name>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="20"/>
+        <location filename="QUPreparatoryTask.cpp" line="22"/>
         <source>Assign missing files automatically</source>
         <translation>Asignar archivos faltantes automáticamente</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="21"/>
+        <location filename="QUPreparatoryTask.cpp" line="23"/>
         <source>&lt;b&gt;#MP3&lt;/b&gt; ... first audio file found.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... first video file found.&lt;br&gt;&lt;br&gt;Does not reset tags that have already been set.</source>
         <translation>&lt;b&gt;#MP3&lt;/b&gt; ... primer archivo de audio encontrado.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... primer archivo de imagen, según un patrón.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... primer archivo de imagen, según un patrón.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... primer archivo de video encontrado.&lt;br&gt;&lt;br&gt;No restaura las etiquetas que ya han sido colocadas.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="29"/>
+        <location filename="QUPreparatoryTask.cpp" line="31"/>
         <source>Fix or remove unsupported tags</source>
         <oldsource>Remove unsupported tags</oldsource>
         <translation type="unfinished">Eliminar etiquetas no soportadas</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="30"/>
+        <location filename="QUPreparatoryTask.cpp" line="32"/>
         <source>Replaces the incorrect &lt;b&gt;#AUTHOR&lt;/b&gt; tag by the correct &lt;b&gt;#CREATOR&lt;/b&gt; tag and deletes all other unsupported tags.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="34"/>
+        <location filename="QUPreparatoryTask.cpp" line="36"/>
         <source>Fix audio length via #END tag</source>
         <translation>Fijar duración de la pista de audio con la etiqueta #END</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="35"/>
+        <location filename="QUPreparatoryTask.cpp" line="37"/>
         <source>Sets &lt;b&gt;#END&lt;/b&gt; to the length of the song if audio file present and longer than song. &lt;b&gt;Appends a little time buffer.&lt;/b&gt;</source>
         <translation>Establece &lt;b&gt;#END&lt;/b&gt; a la duración de la canción si la pista de audio existe y es más larga que la canción. &lt;b&gt;Añade un pequeño buffer de tiempo.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="39"/>
+        <location filename="QUPreparatoryTask.cpp" line="41"/>
         <source>Round #GAP to nearest integer</source>
         <oldsource>Round #GAP to nearest integer.</oldsource>
         <translation>Redondear #GAP al entero más cercano</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="43"/>
+        <location filename="QUPreparatoryTask.cpp" line="45"/>
         <source>Capitalize #TITLE tag</source>
         <oldsource>Fix capitalization of #TITLE tag</oldsource>
         <translation>Poner e mayúsculas la etiqueta #TITLE</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="44"/>
+        <location filename="QUPreparatoryTask.cpp" line="46"/>
         <source>Applies some rules of capitalization to form a consistent appearance for all song titles.&lt;br&gt;&lt;br&gt;&lt;b&gt;Useful for english songs.&lt;/b&gt;</source>
         <translation>Aplica algunas reglas de mayúsculas para conseguir una apariencia consistente entre los títulos de las canciones.&lt;br&gt;&lt;br&gt;&lt;b&gt;Útil para canciones en inglés.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="48"/>
+        <location filename="QUPreparatoryTask.cpp" line="50"/>
         <source>Capitalize #ARTIST tag</source>
         <translation>Poner en mayúsculas la etiqueta #ARTIST</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="49"/>
+        <location filename="QUPreparatoryTask.cpp" line="51"/>
         <source>Capitalize each word of the artist, e.g. &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</source>
         <translation>Utiliza mayúsculas en cada palabra del artista, ej.: &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <location filename="QUPreparatoryTask.cpp" line="55"/>
         <source>Set #EDITION tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <location filename="QUPreparatoryTask.cpp" line="56"/>
         <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <location filename="QUPreparatoryTask.cpp" line="60"/>
         <source>Set #GENRE tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <location filename="QUPreparatoryTask.cpp" line="61"/>
         <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <location filename="QUPreparatoryTask.cpp" line="65"/>
         <source>Fix #LANGUAGE tag to contain English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <location filename="QUPreparatoryTask.cpp" line="66"/>
         <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <location filename="QUPreparatoryTask.cpp" line="70"/>
         <source>Fix apostrophes in song artist and title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <location filename="QUPreparatoryTask.cpp" line="71"/>
         <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <location filename="QUPreparatoryTask.cpp" line="75"/>
         <source>Add missing ’P1’ and ’P2’ in duets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <location filename="QUPreparatoryTask.cpp" line="76"/>
         <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="80"/>
+        <source>Fix line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="81"/>
+        <source>Change the .txt line endings to either CRLF or LF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Pattern:</source>
         <translation>Patron:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
         <source>(cover)</source>
         <translation>(carátula)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>(background)</source>
         <translation>(imagen de fondo)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>Buffer:</source>
         <translation>Buffer:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="145"/>
+        <location filename="QUPreparatoryTask.cpp" line="155"/>
         <source>Capitalize English songs only</source>
         <translation>Utilizar mayúsculas solo en las canciones en inglés</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="146"/>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
         <source>Capitalize each word</source>
         <translation>Utilizar mayúsculas en cada palabra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="147"/>
-        <location filename="QUPreparatoryTask.cpp" line="150"/>
+        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="160"/>
         <source>Capitalize first word only</source>
         <translation>Utilizar mayúsculas solo en la primera palabra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <location filename="QUPreparatoryTask.cpp" line="163"/>
         <source>Edition:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <location filename="QUPreparatoryTask.cpp" line="166"/>
         <source>Genre:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="195"/>
+        <location filename="QUPreparatoryTask.cpp" line="169"/>
+        <source>Convert to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="208"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>Uso de mayúsculas no corresponde por no ser una canción en inglés: &quot;%1 - %2&quot;. Intenta configurar la tarea.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <location filename="QUPreparatoryTask.cpp" line="216"/>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <location filename="QUPreparatoryTask.cpp" line="294"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <location filename="QUPreparatoryTask.cpp" line="309"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <location filename="QUPreparatoryTask.cpp" line="318"/>
         <source>#EDITION set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <location filename="QUPreparatoryTask.cpp" line="328"/>
         <source>#GENRE set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <location filename="QUPreparatoryTask.cpp" line="392"/>
         <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <location filename="QUPreparatoryTask.cpp" line="408"/>
         <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <location filename="QUPreparatoryTask.cpp" line="437"/>
         <source>Line: %1, Note: %2, Diff: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <location filename="QUPreparatoryTask.cpp" line="444"/>
         <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <location filename="QUPreparatoryTask.cpp" line="469"/>
         <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/plugins/preparatory/preparatory.fr.ts
+++ b/src/plugins/preparatory/preparatory.fr.ts
@@ -22,222 +22,237 @@
 <context>
     <name>QUPreparatoryTask</name>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="20"/>
+        <location filename="QUPreparatoryTask.cpp" line="22"/>
         <source>Assign missing files automatically</source>
         <translation>Assigner les fichiers manquants automatiquement</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="21"/>
+        <location filename="QUPreparatoryTask.cpp" line="23"/>
         <source>&lt;b&gt;#MP3&lt;/b&gt; ... first audio file found.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... first video file found.&lt;br&gt;&lt;br&gt;Does not reset tags that have already been set.</source>
         <translation>&lt;b&gt;#MP3&lt;/b&gt; ... premier fichier audio trouvé.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... première image suivant le modèle.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... première image suivant le modèle.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... premier fichier vidéo trouvé.&lt;br&gt;&lt;br&gt;Pas de remise à zéro des champs qui sont déjà fixés.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="29"/>
+        <location filename="QUPreparatoryTask.cpp" line="31"/>
         <source>Fix or remove unsupported tags</source>
         <oldsource>Remove unsupported tags</oldsource>
         <translation type="unfinished">Suppression des champs non supportés</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="30"/>
+        <location filename="QUPreparatoryTask.cpp" line="32"/>
         <source>Replaces the incorrect &lt;b&gt;#AUTHOR&lt;/b&gt; tag by the correct &lt;b&gt;#CREATOR&lt;/b&gt; tag and deletes all other unsupported tags.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="34"/>
+        <location filename="QUPreparatoryTask.cpp" line="36"/>
         <source>Fix audio length via #END tag</source>
         <translation>Corriger la longueur du fichier audio grâce au champ #END</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="35"/>
+        <location filename="QUPreparatoryTask.cpp" line="37"/>
         <source>Sets &lt;b&gt;#END&lt;/b&gt; to the length of the song if audio file present and longer than song. &lt;b&gt;Appends a little time buffer.&lt;/b&gt;</source>
         <translation>Fixer &lt;b&gt;#END&lt;/b&gt; à la longueur de la chanson si le fichier audio présent est plus long que la chanson. &lt;b&gt;Nécessite un peu de temps pour mettre en mémoire tampon.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="39"/>
+        <location filename="QUPreparatoryTask.cpp" line="41"/>
         <source>Round #GAP to nearest integer</source>
         <oldsource>Round #GAP to nearest integer.</oldsource>
         <translation>Arrondir #GAP à la valeur entière la plus proche</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="43"/>
+        <location filename="QUPreparatoryTask.cpp" line="45"/>
         <source>Capitalize #TITLE tag</source>
         <oldsource>Fix capitalization of #TITLE tag</oldsource>
         <translation>Mettre en capitale le champ #TITLE</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="44"/>
+        <location filename="QUPreparatoryTask.cpp" line="46"/>
         <source>Applies some rules of capitalization to form a consistent appearance for all song titles.&lt;br&gt;&lt;br&gt;&lt;b&gt;Useful for english songs.&lt;/b&gt;</source>
         <translation>Appliquer des règles de majuscule/minuscule pour créer une cohérence dans les titres des chansons.&lt;br&gt;&lt;br&gt;&lt;b&gt; Utile pour les chansons anglaises.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="48"/>
+        <location filename="QUPreparatoryTask.cpp" line="50"/>
         <source>Capitalize #ARTIST tag</source>
         <translation>Mettre les capitales dans le champ #ARTIST</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="49"/>
+        <location filename="QUPreparatoryTask.cpp" line="51"/>
         <source>Capitalize each word of the artist, e.g. &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</source>
         <translation>Mettre des capitales à chaque mot du champ #ARTIST, par exemple &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <location filename="QUPreparatoryTask.cpp" line="55"/>
         <source>Set #EDITION tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <location filename="QUPreparatoryTask.cpp" line="56"/>
         <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <location filename="QUPreparatoryTask.cpp" line="60"/>
         <source>Set #GENRE tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <location filename="QUPreparatoryTask.cpp" line="61"/>
         <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <location filename="QUPreparatoryTask.cpp" line="65"/>
         <source>Fix #LANGUAGE tag to contain English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <location filename="QUPreparatoryTask.cpp" line="66"/>
         <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <location filename="QUPreparatoryTask.cpp" line="70"/>
         <source>Fix apostrophes in song artist and title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <location filename="QUPreparatoryTask.cpp" line="71"/>
         <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <location filename="QUPreparatoryTask.cpp" line="75"/>
         <source>Add missing ’P1’ and ’P2’ in duets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <location filename="QUPreparatoryTask.cpp" line="76"/>
         <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="80"/>
+        <source>Fix line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="81"/>
+        <source>Change the .txt line endings to either CRLF or LF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Pattern:</source>
         <translation>Modèle:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
         <source>(cover)</source>
         <translation>(couverture)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>(background)</source>
         <translation>(fond d&apos;écran)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>Buffer:</source>
         <translation>Mémoire tampon:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>seconds</source>
         <translation>secondes</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="145"/>
+        <location filename="QUPreparatoryTask.cpp" line="155"/>
         <source>Capitalize English songs only</source>
         <translation>Ne mettre des capitales que dans les chansons anglaises</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="146"/>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
         <source>Capitalize each word</source>
         <translation>Mettre des capitales à tous les mots</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="147"/>
-        <location filename="QUPreparatoryTask.cpp" line="150"/>
+        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="160"/>
         <source>Capitalize first word only</source>
         <translation>Mettre des capitales qu&apos;aux premiers mots</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <location filename="QUPreparatoryTask.cpp" line="163"/>
         <source>Edition:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <location filename="QUPreparatoryTask.cpp" line="166"/>
         <source>Genre:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="195"/>
+        <location filename="QUPreparatoryTask.cpp" line="169"/>
+        <source>Convert to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="208"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>La correction des capitales n&apos;est pas applicable à &quot;%1 - %2&quot; car ce n&apos;est pas une chanson anglaise. Essayez de configurer la tâche.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <location filename="QUPreparatoryTask.cpp" line="216"/>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <location filename="QUPreparatoryTask.cpp" line="294"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <location filename="QUPreparatoryTask.cpp" line="309"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <location filename="QUPreparatoryTask.cpp" line="318"/>
         <source>#EDITION set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <location filename="QUPreparatoryTask.cpp" line="328"/>
         <source>#GENRE set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <location filename="QUPreparatoryTask.cpp" line="392"/>
         <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <location filename="QUPreparatoryTask.cpp" line="408"/>
         <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <location filename="QUPreparatoryTask.cpp" line="437"/>
         <source>Line: %1, Note: %2, Diff: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <location filename="QUPreparatoryTask.cpp" line="444"/>
         <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <location filename="QUPreparatoryTask.cpp" line="469"/>
         <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/plugins/preparatory/preparatory.pl.ts
+++ b/src/plugins/preparatory/preparatory.pl.ts
@@ -22,7 +22,7 @@
 <context>
     <name>QUPreparatoryTask</name>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="20"/>
+        <location filename="QUPreparatoryTask.cpp" line="22"/>
         <source>Assign missing files automatically</source>
         <translation>Przypisz automatycznie brakujące pliki</translation>
     </message>
@@ -31,217 +31,232 @@
         <translation type="obsolete">&lt;b&gt;#MP3&lt;/b&gt; ... pierwszy znaleziony plik z muzyką.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... pierwszy plik graficzny, który zawiera w nazwie: &lt;i&gt;[CO]&lt;/i&gt;.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... pierwszy plik graficzny, który zawiera w nazwie: &lt;i&gt;[BG]&lt;/i&gt;.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ...pierwszy plik z teledyskiem.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="21"/>
+        <location filename="QUPreparatoryTask.cpp" line="23"/>
         <source>&lt;b&gt;#MP3&lt;/b&gt; ... first audio file found.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... first video file found.&lt;br&gt;&lt;br&gt;Does not reset tags that have already been set.</source>
         <translation>&lt;b&gt;#MP3&lt;/b&gt; ... pierwszy znaleziony plik z muzyką&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... pierwszy plik graficzny&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... pierwszy plik graficzny.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... pierwszy plik teledysku znaleziony.&lt;br&gt;&lt;br&gt;Nie resetuje eykiet, które zostały już ustawione.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="29"/>
+        <location filename="QUPreparatoryTask.cpp" line="31"/>
         <source>Fix or remove unsupported tags</source>
         <oldsource>Remove unsupported tags</oldsource>
         <translation type="unfinished">Usuwanie nierozpoznanych etykiet</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="30"/>
+        <location filename="QUPreparatoryTask.cpp" line="32"/>
         <source>Replaces the incorrect &lt;b&gt;#AUTHOR&lt;/b&gt; tag by the correct &lt;b&gt;#CREATOR&lt;/b&gt; tag and deletes all other unsupported tags.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="34"/>
+        <location filename="QUPreparatoryTask.cpp" line="36"/>
         <source>Fix audio length via #END tag</source>
         <translation>Popraw długość utworu w oparciu o etykietę #END</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="35"/>
+        <location filename="QUPreparatoryTask.cpp" line="37"/>
         <source>Sets &lt;b&gt;#END&lt;/b&gt; to the length of the song if audio file present and longer than song. &lt;b&gt;Appends a little time buffer.&lt;/b&gt;</source>
         <translation>Ustawia &lt;b&gt;#END&lt;/b&gt; z wpisem długości utworu, przydatne gdy plik z muzyką jest dłuższy od utworu. &lt;b&gt;Dodaje nieco czasu.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="39"/>
+        <location filename="QUPreparatoryTask.cpp" line="41"/>
         <source>Round #GAP to nearest integer</source>
         <oldsource>Round #GAP to nearest integer.</oldsource>
         <translation>Przybliż #GAP do najbliższej liczby po przecinku</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="43"/>
+        <location filename="QUPreparatoryTask.cpp" line="45"/>
         <source>Capitalize #TITLE tag</source>
         <oldsource>Fix capitalization of #TITLE tag</oldsource>
         <translation>&quot;Wielką Literą&quot; tytuł</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="44"/>
+        <location filename="QUPreparatoryTask.cpp" line="46"/>
         <source>Applies some rules of capitalization to form a consistent appearance for all song titles.&lt;br&gt;&lt;br&gt;&lt;b&gt;Useful for english songs.&lt;/b&gt;</source>
         <translation>Funkcja &quot;Wielką Literą&quot; zmienia pierwsze małe litery na wielkie tworząc spójny wygląd tytułów piosenek.&lt;br&gt;&lt;br&gt;&lt;b&gt;Uzywaj do angielskich piosenek.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="48"/>
+        <location filename="QUPreparatoryTask.cpp" line="50"/>
         <source>Capitalize #ARTIST tag</source>
         <translation>&quot;Wielką Literą&quot; wykonawca</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="49"/>
+        <location filename="QUPreparatoryTask.cpp" line="51"/>
         <source>Capitalize each word of the artist, e.g. &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</source>
         <translation>&quot;Wielką Literą&quot; nazwa wykonawcy, np. &quot;sylwia grzeszczak&quot; -&gt; &quot;Sylwia Grzeszczak&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <location filename="QUPreparatoryTask.cpp" line="55"/>
         <source>Set #EDITION tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <location filename="QUPreparatoryTask.cpp" line="56"/>
         <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <location filename="QUPreparatoryTask.cpp" line="60"/>
         <source>Set #GENRE tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <location filename="QUPreparatoryTask.cpp" line="61"/>
         <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <location filename="QUPreparatoryTask.cpp" line="65"/>
         <source>Fix #LANGUAGE tag to contain English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <location filename="QUPreparatoryTask.cpp" line="66"/>
         <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <location filename="QUPreparatoryTask.cpp" line="70"/>
         <source>Fix apostrophes in song artist and title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <location filename="QUPreparatoryTask.cpp" line="71"/>
         <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <location filename="QUPreparatoryTask.cpp" line="75"/>
         <source>Add missing ’P1’ and ’P2’ in duets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <location filename="QUPreparatoryTask.cpp" line="76"/>
         <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="80"/>
+        <source>Fix line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="81"/>
+        <source>Change the .txt line endings to either CRLF or LF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Pattern:</source>
         <translation>Wzór:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
         <source>(cover)</source>
         <translation>(okładka)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>(background)</source>
         <translation>(tło)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>Buffer:</source>
         <translation>Bufor:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>seconds</source>
         <translation>sekundy</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="145"/>
+        <location filename="QUPreparatoryTask.cpp" line="155"/>
         <source>Capitalize English songs only</source>
         <translation>&quot;Wielką Literą&quot; tylko angielskie piosenki</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="146"/>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
         <source>Capitalize each word</source>
         <translation>&quot;Wielką Literą&quot; każde słowo</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="147"/>
-        <location filename="QUPreparatoryTask.cpp" line="150"/>
+        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="160"/>
         <source>Capitalize first word only</source>
         <translation>&quot;Wielką Literą&quot; tylko pierwsze słowo</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <location filename="QUPreparatoryTask.cpp" line="163"/>
         <source>Edition:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <location filename="QUPreparatoryTask.cpp" line="166"/>
         <source>Genre:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="195"/>
+        <location filename="QUPreparatoryTask.cpp" line="169"/>
+        <source>Convert to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="208"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>&quot;Wielką Literą&quot; nie może być zastosowane do nieangielskich piosenek: &quot;%1 - %2&quot;. Spróbuj zmienić zadanie.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <location filename="QUPreparatoryTask.cpp" line="216"/>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <location filename="QUPreparatoryTask.cpp" line="294"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <location filename="QUPreparatoryTask.cpp" line="309"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <location filename="QUPreparatoryTask.cpp" line="318"/>
         <source>#EDITION set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <location filename="QUPreparatoryTask.cpp" line="328"/>
         <source>#GENRE set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <location filename="QUPreparatoryTask.cpp" line="392"/>
         <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <location filename="QUPreparatoryTask.cpp" line="408"/>
         <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <location filename="QUPreparatoryTask.cpp" line="437"/>
         <source>Line: %1, Note: %2, Diff: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <location filename="QUPreparatoryTask.cpp" line="444"/>
         <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <location filename="QUPreparatoryTask.cpp" line="469"/>
         <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/plugins/preparatory/preparatory.pro
+++ b/src/plugins/preparatory/preparatory.pro
@@ -5,6 +5,7 @@ SOURCES = ../shared/QUMultilingualTaskFactory.cpp \
 	../shared/QUSimpleTaskFactory.cpp \
 	../shared/QUSmartSetting.cpp \
 	../shared/QUSmartCheckBox.cpp \
+	../shared/QUSmartComboBox.cpp \
 	../shared/QUSmartInputField.cpp \
 	../../QUSongSupport.cpp
 HEADERS = ../shared/QUMultilingualTaskFactory.h \
@@ -14,6 +15,7 @@ HEADERS = ../shared/QUMultilingualTaskFactory.h \
 	../shared/QUSimpleTaskFactory.h \
 	../shared/QUSmartSetting.h \
 	../shared/QUSmartCheckBox.h \
+	../shared/QUSmartComboBox.h \
 	../shared/QUSmartInputField.h \
 	../../QUSongSupport.h \
 	../QUSmartSettingInterface.h

--- a/src/plugins/preparatory/preparatory.pt.ts
+++ b/src/plugins/preparatory/preparatory.pt.ts
@@ -22,222 +22,237 @@
 <context>
     <name>QUPreparatoryTask</name>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="20"/>
+        <location filename="QUPreparatoryTask.cpp" line="22"/>
         <source>Assign missing files automatically</source>
         <translation>Atribuir ficheiros ausentes automaticamente</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="21"/>
+        <location filename="QUPreparatoryTask.cpp" line="23"/>
         <source>&lt;b&gt;#MP3&lt;/b&gt; ... first audio file found.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... first picture file, following a pattern.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... first video file found.&lt;br&gt;&lt;br&gt;Does not reset tags that have already been set.</source>
         <translation>&lt;b&gt;#MP3&lt;/b&gt; ... primeiro ficheiro audio encontrado.&lt;br&gt;&lt;b&gt;#COVER&lt;/b&gt; ... primeiro ficheiro imagem, seguindo um padrão.&lt;br&gt;&lt;b&gt;#BACKGROUND&lt;/b&gt; ... primeiro ficheiro imagem, seguindo um padrão.&lt;br&gt;&lt;b&gt;#VIDEO&lt;/b&gt; ... primeiro ficheiro video encontrado.&lt;br&gt;&lt;br&gt;Não repor etiquetas já definidas.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="29"/>
+        <location filename="QUPreparatoryTask.cpp" line="31"/>
         <source>Fix or remove unsupported tags</source>
         <oldsource>Remove unsupported tags</oldsource>
         <translation type="unfinished">Remover etiquetas não suportadas</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="30"/>
+        <location filename="QUPreparatoryTask.cpp" line="32"/>
         <source>Replaces the incorrect &lt;b&gt;#AUTHOR&lt;/b&gt; tag by the correct &lt;b&gt;#CREATOR&lt;/b&gt; tag and deletes all other unsupported tags.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="34"/>
+        <location filename="QUPreparatoryTask.cpp" line="36"/>
         <source>Fix audio length via #END tag</source>
         <translation>Corrigir comprimento de audio via etiqueta #END</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="35"/>
+        <location filename="QUPreparatoryTask.cpp" line="37"/>
         <source>Sets &lt;b&gt;#END&lt;/b&gt; to the length of the song if audio file present and longer than song. &lt;b&gt;Appends a little time buffer.&lt;/b&gt;</source>
         <translation>Definir etiqueta &lt;b&gt;#END&lt;/b&gt; ao comprimento da canção se ficheiro audio presente e maior que canção. &lt;b&gt;Adicionar pequeno tempo de buffer.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="39"/>
+        <location filename="QUPreparatoryTask.cpp" line="41"/>
         <source>Round #GAP to nearest integer</source>
         <oldsource>Round #GAP to nearest integer.</oldsource>
         <translation>Arredondar #GAP para o inteiro mais próximo</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="43"/>
+        <location filename="QUPreparatoryTask.cpp" line="45"/>
         <source>Capitalize #TITLE tag</source>
         <oldsource>Fix capitalization of #TITLE tag</oldsource>
         <translation>Capitalizar etiqueta #TITLE</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="44"/>
+        <location filename="QUPreparatoryTask.cpp" line="46"/>
         <source>Applies some rules of capitalization to form a consistent appearance for all song titles.&lt;br&gt;&lt;br&gt;&lt;b&gt;Useful for english songs.&lt;/b&gt;</source>
         <translation>Aplicar algumas regras de capitalização para formar uma aparência consistente para todas as canções.&lt;br&gt;&lt;br&gt;&lt;b&gt;Útil para as canções inglesas.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="48"/>
+        <location filename="QUPreparatoryTask.cpp" line="50"/>
         <source>Capitalize #ARTIST tag</source>
         <translation>Capitalizar etiqueta #ARTIST</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="49"/>
+        <location filename="QUPreparatoryTask.cpp" line="51"/>
         <source>Capitalize each word of the artist, e.g. &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</source>
         <translation>Capitalizar cada palavra do artista, ex: &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <location filename="QUPreparatoryTask.cpp" line="55"/>
         <source>Set #EDITION tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <location filename="QUPreparatoryTask.cpp" line="56"/>
         <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <location filename="QUPreparatoryTask.cpp" line="60"/>
         <source>Set #GENRE tag if it is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <location filename="QUPreparatoryTask.cpp" line="61"/>
         <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <location filename="QUPreparatoryTask.cpp" line="65"/>
         <source>Fix #LANGUAGE tag to contain English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <location filename="QUPreparatoryTask.cpp" line="66"/>
         <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <location filename="QUPreparatoryTask.cpp" line="70"/>
         <source>Fix apostrophes in song artist and title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <location filename="QUPreparatoryTask.cpp" line="71"/>
         <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <location filename="QUPreparatoryTask.cpp" line="75"/>
         <source>Add missing ’P1’ and ’P2’ in duets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <location filename="QUPreparatoryTask.cpp" line="76"/>
         <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="80"/>
+        <source>Fix line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="81"/>
+        <source>Change the .txt line endings to either CRLF or LF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Pattern:</source>
         <translation>Padrão:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="144"/>
         <source>(cover)</source>
         <translation>(capa)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="135"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>(background)</source>
         <translation>(fundo)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>Buffer:</source>
         <translation>Buffer:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="142"/>
+        <location filename="QUPreparatoryTask.cpp" line="152"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="145"/>
+        <location filename="QUPreparatoryTask.cpp" line="155"/>
         <source>Capitalize English songs only</source>
         <translation>Capitalizar apenas canções inglesas</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="146"/>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
         <source>Capitalize each word</source>
         <translation>Capitalizar cada palavra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="147"/>
-        <location filename="QUPreparatoryTask.cpp" line="150"/>
+        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="160"/>
         <source>Capitalize first word only</source>
         <translation>Capitalizar apenas primeira palavra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <location filename="QUPreparatoryTask.cpp" line="163"/>
         <source>Edition:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <location filename="QUPreparatoryTask.cpp" line="166"/>
         <source>Genre:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="195"/>
+        <location filename="QUPreparatoryTask.cpp" line="169"/>
+        <source>Convert to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="208"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>Corrigir capitalização não aplicável, devido às canções não-inglesas: &quot;%1 -%2&quot;. Tente configurar a tarefa.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <location filename="QUPreparatoryTask.cpp" line="216"/>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <location filename="QUPreparatoryTask.cpp" line="294"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <location filename="QUPreparatoryTask.cpp" line="309"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <location filename="QUPreparatoryTask.cpp" line="318"/>
         <source>#EDITION set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <location filename="QUPreparatoryTask.cpp" line="328"/>
         <source>#GENRE set to &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <location filename="QUPreparatoryTask.cpp" line="392"/>
         <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <location filename="QUPreparatoryTask.cpp" line="408"/>
         <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <location filename="QUPreparatoryTask.cpp" line="437"/>
         <source>Line: %1, Note: %2, Diff: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <location filename="QUPreparatoryTask.cpp" line="444"/>
         <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <location filename="QUPreparatoryTask.cpp" line="469"/>
         <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/plugins/shared/QUSmartComboBox.cpp
+++ b/src/plugins/shared/QUSmartComboBox.cpp
@@ -1,0 +1,41 @@
+#include "QUSmartComboBox.h"
+
+#include <QHBoxLayout>
+#include <QToolButton>
+#include <QLabel>
+
+QUSmartComboBox::QUSmartComboBox(const QString &registryKey, const QString &text, const QStringList &values, int defaultValue):
+	QUSmartSetting(registryKey)
+{
+	_defaultValue = defaultValue;
+	saveDefaultValue(_defaultValue);
+
+	_comboBox = new QComboBox();
+    _comboBox->addItems(values);
+    _comboBox->setCurrentIndex(defaultValue);
+	connect(_comboBox, &QComboBox::currentIndexChanged, this, &QUSmartComboBox::updateValue);
+
+	_container = new QWidget();
+
+	QHBoxLayout *layout = new QHBoxLayout();
+    layout->addWidget(new QLabel(text));
+	layout->addWidget(_comboBox);
+	layout->addSpacerItem(new QSpacerItem(20, 5, QSizePolicy::Expanding, QSizePolicy::Fixed));
+	layout->addWidget(createResetButton());
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->setSpacing(2);
+
+	_container->setLayout(layout);
+}
+
+void QUSmartComboBox::updateValue(int index) {
+	setValue(index);
+}
+
+void QUSmartComboBox::resetToDefaults() {
+	_comboBox->setCurrentIndex(_defaultValue);
+}
+
+bool QUSmartComboBox::hasChanges() const {
+	return _defaultValue != _comboBox->currentIndex();
+}

--- a/src/plugins/shared/QUSmartComboBox.h
+++ b/src/plugins/shared/QUSmartComboBox.h
@@ -1,0 +1,30 @@
+#ifndef QUSMARTCOMBOBOX_H_H
+#define QUSMARTCOMBOBOX_H_H
+
+#include "QUSmartSetting.h"
+
+#include <QComboBox>
+#include <QStringList>
+
+class QUSmartComboBox: public QUSmartSetting {
+	Q_OBJECT
+
+public:
+	QUSmartComboBox(const QString &registryKey, const QString &text, const QStringList &values, int defaultValue = 0);
+    ~QUSmartComboBox() override = default;
+
+	virtual QWidget* editor() const { return _container; }
+
+	virtual void resetToDefaults();
+	virtual bool hasChanges() const;
+
+public slots:
+	void updateValue(int index);
+
+private:
+	int _defaultValue;
+	QComboBox *_comboBox;
+	QWidget *_container;
+};
+
+#endif // QUSMARTCOMBOBOX_H_H

--- a/src/resources/lang/UltraStar-Manager.de.ts
+++ b/src/resources/lang/UltraStar-Manager.de.ts
@@ -5883,276 +5883,281 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">&quot;%1&quot; wird nicht unterstützt. Verwende %2 für die Lieddatei: &quot;%3&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="228"/>
+        <location filename="../../song/QUSongFile.cpp" line="238"/>
         <source>Encoding mismatch. Defaulting to %1 for song file: &quot;%2&quot;</source>
         <translation>Codierungsdiskrepanz. Verwende %1 Codierung für Lieddatei: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="233"/>
+        <location filename="../../song/QUSongFile.cpp" line="243"/>
         <source>&quot;%1&quot; unsupported. Defaulting to %2 for song file: &quot;%3&quot;</source>
         <translation>&quot;%1&quot; wird nicht unterstützt. Verwende %2 für Lieddatei: &quot;%3&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="709"/>
+        <location filename="../../song/QUSongFile.cpp" line="719"/>
         <source>Save error! The song file &quot;%1&quot; was NOT saved.</source>
         <translation>Fehler beim Speichern! Die Songdatei &quot;%1&quot; wurde NICHT gespeichert.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="768"/>
+        <location filename="../../song/QUSongFile.cpp" line="775"/>
         <source>The song file &quot;%1&quot; was saved successfully.</source>
         <translation>Die Songdatei &quot;%1&quot; wurde erfolgreich gespeichert.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="810"/>
+        <location filename="../../song/QUSongFile.cpp" line="817"/>
         <source>Could NOT rename the song directory &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Umbenennen fehlgeschlagen! Verzeichnis &quot;%1&quot; konnte nicht nach &quot;%2&quot; umbenannt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="818"/>
+        <location filename="../../song/QUSongFile.cpp" line="825"/>
         <source>Song directory renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Ordner erfolgreich umbenannt von &quot;%1&quot; nach &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="829"/>
+        <location filename="../../song/QUSongFile.cpp" line="836"/>
         <source>Could NOT rename the song file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Umbenennen fehlgeschlagen! Songdatei &quot;%1&quot; konnte nicht nach &quot;%2&quot; umbenannt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="836"/>
+        <location filename="../../song/QUSongFile.cpp" line="843"/>
         <source>Song file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Songdatei erfolgreich umbenannt von &quot;%1&quot; nach &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="848"/>
+        <location filename="../../song/QUSongFile.cpp" line="855"/>
         <source>Could NOT rename the audio file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Umbenennen fehlgeschlagen! Audio-Datei &quot;%1&quot; konnte nicht nach &quot;%2&quot; umbenannt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="853"/>
-        <location filename="../../song/QUSongFile.cpp" line="923"/>
+        <location filename="../../song/QUSongFile.cpp" line="860"/>
+        <location filename="../../song/QUSongFile.cpp" line="930"/>
         <source>Audio file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Audio-Datei erfolgreich umbenannt von &quot;%1&quot; nach &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="870"/>
+        <location filename="../../song/QUSongFile.cpp" line="877"/>
         <source>Could NOT rename the cover picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Umbenennen fehlgeschlagen! Cover &quot;%1&quot; konnte nicht nach &quot;%2&quot; umbenannt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="875"/>
-        <location filename="../../song/QUSongFile.cpp" line="901"/>
+        <location filename="../../song/QUSongFile.cpp" line="882"/>
+        <location filename="../../song/QUSongFile.cpp" line="908"/>
         <source>Cover picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Cover erfolgreich umbenannt von &quot;%1&quot; nach &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="892"/>
+        <location filename="../../song/QUSongFile.cpp" line="899"/>
         <source>Could NOT rename the background picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Umbenennen fehlgeschlagen! Hintergrund &quot;%1&quot; konnte nicht nach &quot;%2&quot; umbenannt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="879"/>
-        <location filename="../../song/QUSongFile.cpp" line="897"/>
+        <location filename="../../song/QUSongFile.cpp" line="886"/>
+        <location filename="../../song/QUSongFile.cpp" line="904"/>
         <source>Background picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Hintergrund erfolgreich umbenannt von &quot;%1&quot; nach &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="914"/>
+        <location filename="../../song/QUSongFile.cpp" line="921"/>
         <source>Could NOT rename the video file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Umbenennen fehlgeschlagen! Video &quot;%1&quot; konnte nicht nach &quot;%2&quot; umbenannt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="857"/>
-        <location filename="../../song/QUSongFile.cpp" line="919"/>
+        <location filename="../../song/QUSongFile.cpp" line="864"/>
+        <location filename="../../song/QUSongFile.cpp" line="926"/>
         <source>Video file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Video erfolgreich umbenannt von &quot;%1&quot; nach &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="204"/>
+        <location filename="../../song/QUSongFile.cpp" line="198"/>
+        <source>Failed to detect line endings in file &quot;%1&quot;, defaulting to CRLF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../song/QUSongFile.cpp" line="214"/>
         <source>UTF8 detected in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="217"/>
+        <location filename="../../song/QUSongFile.cpp" line="227"/>
         <source>ENCODING:CP1252 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="222"/>
+        <location filename="../../song/QUSongFile.cpp" line="232"/>
         <source>ENCODING:CP1250 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="242"/>
+        <location filename="../../song/QUSongFile.cpp" line="252"/>
         <source>Not a valid UTF8 file and ENCODING tag missing. Defaulting to %1 in song file: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="933"/>
+        <location filename="../../song/QUSongFile.cpp" line="940"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for artist.</source>
         <translation>Der Song &quot;%1 - %2&quot; besitzt keine gültige Audio-Datei. ID3-Tag kann nicht als Interpret genutzt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="944"/>
+        <location filename="../../song/QUSongFile.cpp" line="951"/>
         <source>The audio file %1 does not contain ID3 tag information about an artist.</source>
         <translation>Die Audio-Datei %1 besitzt keine ID3-Tag-Information über einen Interpreten.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="949"/>
+        <location filename="../../song/QUSongFile.cpp" line="956"/>
         <source>ID3 tag of &quot;%1&quot; used for artist. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>ID3-Tag von &quot;%1&quot; für den Interpreten genutzt. Änderung von &quot;%2&quot; auf &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="954"/>
+        <location filename="../../song/QUSongFile.cpp" line="961"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for title.</source>
         <translation>Der Song &quot;%1 - %2&quot; besitzt keine gültige Audio-Datei. ID3-Tag kann nicht als Titel genutzt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="964"/>
+        <location filename="../../song/QUSongFile.cpp" line="971"/>
         <source>The audio file %1 does not contain ID3 tag information about a title.</source>
         <translation>Die Audio-Datei %1 besitzt keine ID3-Tag-Information über einen Titel.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="969"/>
+        <location filename="../../song/QUSongFile.cpp" line="976"/>
         <source>ID3 tag of &quot;%1&quot; used for title. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>ID3-Tag von &quot;%1&quot; für den Titel genutzt. Änderung von &quot;%2&quot; auf &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="974"/>
+        <location filename="../../song/QUSongFile.cpp" line="981"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for genre.</source>
         <translation>Der Song &quot;%1 - %2&quot; besitzt keine gültige Audio-Datei. ID3-Tag kann nicht für das Genre genutzt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="984"/>
+        <location filename="../../song/QUSongFile.cpp" line="991"/>
         <source>The audio file %1 does not contain ID3 tag information about a genre.</source>
         <translation>Die Audio-Datei %1 besitzt keine ID3-Tag-Information über ein Genre.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="989"/>
+        <location filename="../../song/QUSongFile.cpp" line="996"/>
         <source>ID3 tag of &quot;%1&quot; used for genre. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>ID3-Tag von &quot;%1&quot; für das Genre genutzt. Änderung von &quot;%2&quot; auf &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="994"/>
+        <location filename="../../song/QUSongFile.cpp" line="1001"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for year.</source>
         <translation>Der Song &quot;%1 - %2&quot; besitzt keine gültige Audio-Datei. ID3-Tag kann nicht für das Jahr genutzt werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1004"/>
+        <location filename="../../song/QUSongFile.cpp" line="1011"/>
         <source>The audio file %1 does not contain ID3 tag information about a year.</source>
         <translation>Die Audio-Datei %1 besitzt keine ID3-Tag-Information über ein Jahr.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1009"/>
+        <location filename="../../song/QUSongFile.cpp" line="1016"/>
         <source>ID3 tag of &quot;%1&quot; used for year. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>ID3-Tag von &quot;%1&quot; für das Jahr genutzt. Änderung von &quot;%2&quot; auf &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1014"/>
+        <location filename="../../song/QUSongFile.cpp" line="1021"/>
         <source>The song &quot;%1 - %2&quot; has no unsupported tags.</source>
         <translation>Der Song &quot;%1 - %2&quot; besitzt keine nicht unterstützten Tags.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1022"/>
+        <location filename="../../song/QUSongFile.cpp" line="1029"/>
         <source>Unsupported tag removed: #%1.</source>
         <translation>Nicht unterstützten Tag entfernt: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1024"/>
+        <location filename="../../song/QUSongFile.cpp" line="1031"/>
         <source>Unsupported tag skipped: #%1.</source>
         <translation>Nicht unterstützten Tag übersprungen: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1045"/>
+        <location filename="../../song/QUSongFile.cpp" line="1052"/>
         <source>Assigned &quot;%1&quot; as audio file for &quot;%2 - %3&quot;.</source>
         <translation>Audiodatei für &quot;%2 - %3&quot; geändert auf: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1040"/>
+        <location filename="../../song/QUSongFile.cpp" line="1047"/>
         <source>Assigned &quot;%1&quot; as video file for &quot;%2 - %3&quot;.</source>
         <translation>Video für &quot;%2 - %3&quot; geändert auf: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1053"/>
+        <location filename="../../song/QUSongFile.cpp" line="1060"/>
         <source>Assigned &quot;%1&quot; as cover picture for &quot;%2 - %3&quot;.</source>
         <translation>Cover für &quot;%2 - %3&quot; geändert auf: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1056"/>
+        <location filename="../../song/QUSongFile.cpp" line="1063"/>
         <source>Assigned &quot;%1&quot; as background picture for &quot;%2 - %3&quot;.</source>
         <translation>Hintergrund für &quot;%2 - %3&quot; geändert auf: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1071"/>
+        <location filename="../../song/QUSongFile.cpp" line="1078"/>
         <source>Could not copy the file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Datei &quot;%1&quot; konnte nicht nach &quot;%2&quot; kopiert werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1075"/>
+        <location filename="../../song/QUSongFile.cpp" line="1082"/>
         <source>The file &quot;%1&quot; was successfully copied to &quot;%2&quot;.</source>
         <translation>Die Datei &quot;%1&quot; wurde erfolgreich nach &quot;%2&quot; kopiert.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1107"/>
+        <location filename="../../song/QUSongFile.cpp" line="1114"/>
         <source>File removed successfully: &quot;%1&quot;.</source>
         <translation>Die Datei &quot;%1&quot; wurde erfolgreich gelöscht.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1109"/>
+        <location filename="../../song/QUSongFile.cpp" line="1116"/>
         <source>File COULD NOT be removed: &quot;%1&quot;.</source>
         <translation>Datei konnte NICHT entfernt werden: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1120"/>
+        <location filename="../../song/QUSongFile.cpp" line="1127"/>
         <source>Audio file tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Audiodatei-Tag entfernt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1124"/>
+        <location filename="../../song/QUSongFile.cpp" line="1131"/>
         <source>Cover tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Cover-Tag entfernt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1128"/>
+        <location filename="../../song/QUSongFile.cpp" line="1135"/>
         <source>Background tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Hintergrund-Tag entfernt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1133"/>
+        <location filename="../../song/QUSongFile.cpp" line="1140"/>
         <source>Video tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Video-Tag entfernt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1262"/>
+        <location filename="../../song/QUSongFile.cpp" line="1269"/>
         <source>INCONSISTENT STATE! The song &quot;%1 - %2&quot; has unsaved changes and its persistent song file &quot;%3&quot; was modified externally. Save your changes or rebuild the tree manually.</source>
         <translation>INKONSISTENTER ZUSTAND! Der Song &quot;%1 - %2&quot; hat ungespeicherte Änderungen und seine Songdatei &quot;%3&quot; wurde extern verändert. Speichere deine Änderungen oder aktualisiere den Songbaum manuell.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1268"/>
+        <location filename="../../song/QUSongFile.cpp" line="1275"/>
         <source>Song file changed: &quot;%1&quot;</source>
         <translation>Songdatei geändert: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1444"/>
+        <location filename="../../song/QUSongFile.cpp" line="1451"/>
         <source>Primary song file changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Primärer Song geändert von &quot;%1&quot; auf &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1508"/>
+        <location filename="../../song/QUSongFile.cpp" line="1515"/>
         <source>Error while preparing lyrics for %1 - %2. Could not parse the following line: %3</source>
         <translation>Es ist ein Fehler während des Vorbereitens der Lyrics für &quot;%1 - %2&quot; aufgetreten. Folgende Zeile konnte nicht verarbeitet werden: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1521"/>
+        <location filename="../../song/QUSongFile.cpp" line="1528"/>
         <source>Error while preparing lyrics for %1 - %2. Songs may not start with a line break.</source>
         <translation>Es ist ein Fehler während des Vorbereitens der Lyrics für &quot;%1 - %2&quot; aufgetreten. Lieder dürfen nicht mit einem Zeilenumbruch beginnen.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1601"/>
+        <location filename="../../song/QUSongFile.cpp" line="1608"/>
         <source>More than one score file found for &quot;%1 - %2&quot;. Only one will be used.</source>
         <translation>Mehr als eine Punktedatei gefunden für &quot;%1 - %2&quot;. Nur eine wird benutzt.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="785"/>
+        <location filename="../../song/QUSongFile.cpp" line="792"/>
         <source>Old name and new name match: &quot;%1&quot;</source>
         <translation>Alter und neuer Name stimmen überein: &quot;%1&quot;</translation>
     </message>
@@ -6161,77 +6166,77 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Diskrepanz bei der Codierung. Verwende UTF8 Encodierung für Lieddatei: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="357"/>
+        <location filename="../../song/QUSongFile.cpp" line="367"/>
         <source>Deprecated tag information detected.</source>
         <translation>Veraltete Tag-Information gefunden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="358"/>
+        <location filename="../../song/QUSongFile.cpp" line="368"/>
         <source>The number of available tags in your configuration and that one this application offers are different.</source>
         <translation>Die Anzahl der verfügbaren Tags in deinen Einstellungen stimmt nicht mit der Zahl überein, die diese Anwendung bereitstellt.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="359"/>
+        <location filename="../../song/QUSongFile.cpp" line="369"/>
         <source>The tag order was reset to its default order. Check out the options to set up your custom order again.</source>
         <translation>Die Reihenfolge der Tags wurde zurückgesetzt. Du musst deine angepasste Reihenfolge neu festlegen.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1147"/>
+        <location filename="../../song/QUSongFile.cpp" line="1154"/>
         <source>Old path and new path match! Cannot change song path to: &quot;%1&quot;</source>
         <translation>Alter und neuer Pfad stimmen überein! Songpfad konnte NICHT geändert werden: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1152"/>
+        <location filename="../../song/QUSongFile.cpp" line="1159"/>
         <source>Could not create new song path: &quot;%1&quot;</source>
         <translation>Neuer Songpfad konnte nicht erstellt werden: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1166"/>
+        <location filename="../../song/QUSongFile.cpp" line="1173"/>
         <source>Failed to move &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Die Datei &quot;%1&quot; konnte NICHT nach &quot;%2&quot; verschoben werden.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1169"/>
+        <location filename="../../song/QUSongFile.cpp" line="1176"/>
         <source>The file &quot;%1&quot; was successfully moved to &quot;%2&quot;.</source>
         <translation>Die Datei &quot;%1&quot; wurde erfolgreich nach &quot;%2&quot; verschoben.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1173"/>
+        <location filename="../../song/QUSongFile.cpp" line="1180"/>
         <source>Could NOT move all files of the song &quot;%2&quot; to a new location. Check out &quot;%1&quot; for the files which were copied.</source>
         <translation>Nicht alle Dateien des Songs &quot;%2&quot; konnten an die neue Stelle verschoben werden. Prüfe &quot;%1&quot; für verbliebene Dateien.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1183"/>
+        <location filename="../../song/QUSongFile.cpp" line="1190"/>
         <source>Could not remove old, empty folder &quot;%1&quot;. Please do it manually.</source>
         <translation>Altes, leeres Verzeichnis konnte nicht gelöscht werden: &quot;%1&quot;. Lösche dies bitte manuell.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1190"/>
+        <location filename="../../song/QUSongFile.cpp" line="1197"/>
         <source>Location of song &quot;%1 - %2&quot; successfully changed to &quot;%3&quot; in your UltraStar song folder.</source>
         <translation>Ort des Songs &quot;%1 - %2&quot; erfolgreich geändert nach &quot;%3&quot; im UltraStar Song-Ordner.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1201"/>
+        <location filename="../../song/QUSongFile.cpp" line="1208"/>
         <source>Could not fix audio length because no audio file is present: &quot;%1 - %2&quot;</source>
         <translation>Die Länge der Audio-Datei konnte nicht repariert werden, weil keine Audio-Datei vorhanden ist: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1212"/>
+        <location filename="../../song/QUSongFile.cpp" line="1219"/>
         <source>Could not fix audio length because audio file is shorter than song: &quot;%1 - %2&quot;</source>
         <translation>Die Länge der Audio-Datei konnte nicht repariert werden, weil die Audio-Datei kürzer als der Song ist: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1219"/>
+        <location filename="../../song/QUSongFile.cpp" line="1226"/>
         <source>Could not fix audio length because new value for #END would be greater than length of audio file: &quot;%1 - %2&quot;</source>
         <translation>Die Länge der Audio-Datei konnte nicht repariert werden, weil der neue Wert für#END größer wär, als die Audio-Datei lang ist: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1226"/>
+        <location filename="../../song/QUSongFile.cpp" line="1233"/>
         <source>Audio length was fixed for song &quot;%1 - %2&quot;. #END changed to: %3</source>
         <translation>Audio-Länge wurde neu gesetzt für &quot;%1 - %2&quot;. #END ist jetzt: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1250"/>
+        <location filename="../../song/QUSongFile.cpp" line="1257"/>
         <source>The tag #END was removed for: &quot;%1 - %2&quot;</source>
         <translation>Der #END-Tag wurde entfernt für: &quot;%1 - %2&quot;</translation>
     </message>
@@ -6249,12 +6254,12 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">%1 Ausgabecodierung NICHT ausreichend. Verwende UTF8 für Lieddatei: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1241"/>
+        <location filename="../../song/QUSongFile.cpp" line="1248"/>
         <source>#GAP changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>#GAP wurde von %1 auf %2 geändert für &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1545"/>
+        <location filename="../../song/QUSongFile.cpp" line="1552"/>
         <source>Line too short: &quot;%1&quot;</source>
         <translation>Zeile zu kurz: &quot;%1&quot;</translation>
     </message>
@@ -6421,104 +6426,114 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="144"/>
+        <source>Line Endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="145"/>
+        <source>Shows whether the text file has CRLF or LF line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="149"/>
         <source>Shows the song length calculated from BPM and lyrics.</source>
         <translation>Zeigt die Länge des Songs - berechnet aus BPM und Lyrics.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
         <source>Shows the length of audio file, if present.&lt;br&gt;&lt;br&gt;Can be reset through &lt;b&gt;#END&lt;/b&gt; tag.</source>
         <translation>Zeigt die Länge der Audio-Datei, wenn vorhanden.&lt;br&gt;&lt;br&gt;Kann mittels &lt;b&gt;#END&lt;/b&gt;-Tag neu gesetzt werden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
         <source>Effective</source>
         <translation>Effektiv</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
         <source>Shows the effective song length:&lt;br&gt;&lt;b&gt;audio length - #START&lt;/b&gt;.</source>
         <translation>Zeigt die effektive Länge:&lt;br&gt;&lt;b&gt;Audio-Länge - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="169"/>
         <source>Shows how much time is skipped from the beginning of the audio file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Zeigt an, welche Zeit vom Anfang der Audio-Datei übersprungen werden.&lt;br&gt;&lt;i&gt;(in Sekunden)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1106"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1110"/>
         <source>Calculating selected song ReplayGain...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1372"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
         <source>Calculate Song ReplayGain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1379"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1383"/>
         <source>Open With Finder...</source>
         <translation>Öffne mit Finder...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1382"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
         <source>Open With File Manager...</source>
         <translation>Öffne mit Dateimanager...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
         <source>Search for cover on AlbumArtExchange...</source>
         <translation>Suche nach einem Cover bei AlbumArtExchange...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
         <source>Search for cover on Google Images...</source>
         <translation>Suche nach einem Cover bei Google Bilder...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1391"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
         <source>Search for artwork on Fanart...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
         <source>Search for background on Google Images...</source>
         <translation>Suche nach einem Hintergrundbild bei Google Bilder...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1397"/>
         <source>Search for video on Google Video...</source>
         <translation>Suche nach einem Video bei Google Videos...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1398"/>
         <source>Search for video on Youtube...</source>
         <translation>Suche nach einem Video bei Youtube...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1399"/>
         <source>Look up on Hitparade.ch...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
         <source>Look up on USDB...</source>
         <translation>Dieses Lied bei USDB nachschlagen...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1404"/>
         <source>Create Duet From Song Files</source>
         <translation>Erstelle ein Duett aus den Lieddateien</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1570"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1595"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1618"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1641"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1664"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1686"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1706"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1728"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1574"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1599"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1645"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1668"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1690"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1710"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1732"/>
         <source>You can only look up one song at a time.</source>
         <translation>Es kann nur ein Song gleichzeitig nachgeschaut werden.</translation>
     </message>
@@ -6527,58 +6542,58 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Zeigt an, welche Zeit vom Ende der Audio-Datei übersprungen werden.&lt;br&gt;&lt;i&gt;(in Millisekunden)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
         <source>Shows how much time is skipped from the video file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Zeigt an, welche Zeit vom Anfang der Video-Datei übersprungen werden.&lt;br&gt;&lt;i&gt;(in Sekunden)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="323"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="325"/>
         <source>Saving unsaved changes...</source>
         <translation>Speichere Änderungen...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="394"/>
         <source>Filter removed. All songs are visible now.</source>
         <translation>Filter entfernt. Alle Songs werden jetzt angezeigt.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1349"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1353"/>
         <source>Open externally</source>
         <translation>Extern öffnen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1354"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1358"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1351"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1356"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1360"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1199"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1203"/>
         <source>New song included to your song collection: &quot;%1 - %2&quot;.</source>
         <translation>Neuer Song in die Sammlung eingefügt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1191"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1195"/>
         <source>Could not copy song file &quot;%1&quot; to new song directory &quot;%2&quot;!</source>
         <translation>Konnte die Songdatei &quot;%1&quot; nicht in das neue Songverzeichnis &quot;%2&quot; kopieren!</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1435"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1439"/>
         <source>The file &quot;%1&quot; was deleted successfully.</source>
         <translation>Die Datei &quot;%1&quot; wurde erfolgreich gelöscht.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1437"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1441"/>
         <source>The file &quot;%1&quot; was NOT deleted.</source>
         <translation>Die Datei &quot;%1&quot; konnte NICHT gelöscht werden.</translation>
     </message>
@@ -6588,58 +6603,58 @@ p, li { white-space: pre-wrap; }
         <translation>Ordner (%1)</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="404"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="406"/>
         <source>Applying filter...</source>
         <translation>Filter anwenden...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1131"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1135"/>
         <source>Copy &amp; Use files for the song: &quot;%1 - %2&quot;...</source>
         <translation>Kopiere &amp; benutze Dateien für den Song: &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1303"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1307"/>
         <source>Saving selected songs...</source>
         <translation>Speichere ausgewählte Songs...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1121"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1125"/>
         <source>Copy Files</source>
         <translation>Dateien kopieren</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1122"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1126"/>
         <source>You want to copy &lt;b&gt;%1&lt;/b&gt; files to &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</source>
         <translation>Du willst &lt;b&gt;%1&lt;/b&gt; Dateien nach &lt;b&gt;&quot;%2&quot;&lt;/b&gt; kopieren.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1123"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1127"/>
         <source>Copy these files.</source>
         <translation>Kopiere diese Dateien.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1124"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1128"/>
         <source>Cancel copy operation.</source>
         <translation>Aktion abbrechen.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1427"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1431"/>
         <source>Delete File</source>
         <translation>Datei löschen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1428"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1432"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; will be deleted permanently. You cannot undo a delete operation.</source>
         <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; wird dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1429"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1433"/>
         <source>Delete this file.</source>
         <translation>Lösche diese Datei.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="966"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1430"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="970"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1434"/>
         <source>Cancel delete operation.</source>
         <translation>Aktion abbrechen.</translation>
     </message>
@@ -6684,7 +6699,7 @@ p, li { white-space: pre-wrap; }
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="145"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
         <source>Song</source>
         <translation>Song</translation>
     </message>
@@ -6693,12 +6708,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Länge des Songs - berechnet aus BPM und Lyrics.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="150"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="152"/>
         <source>Indicates a problem with the difference of &lt;i&gt;song length&lt;/i&gt; and &lt;i&gt;audio length&lt;/i&gt;.&lt;br&gt;&lt;br&gt;The tooltip shows the difference.</source>
         <translation>Zeigt ein Problem mit der Differenz von &lt;i&gt;Song-Länge&lt;/i&gt; und &lt;i&gt;Audio-Länge&lt;/i&gt; auf.&lt;br&gt;&lt;br&gt;Der Tooltip gibt den Unterschied an.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="153"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
@@ -6715,7 +6730,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Zeigt die effektive Länge:&lt;br&gt;&lt;b&gt;Audio-Länge - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
@@ -6724,7 +6739,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Überspringt die ersten Sekunden des Songs.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="168"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
         <source>End</source>
         <translation>Ende</translation>
     </message>
@@ -6733,7 +6748,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Setzt die Länge der Audio-Datei.&lt;br&gt;&lt;i&gt;(in Millisekunden)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="171"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
         <source>Videogap</source>
         <translation>Videogap</translation>
     </message>
@@ -6742,7 +6757,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Überspringt die ersten Sekunden des Videos.&lt;br&gt;&lt;br&gt;&lt;i&gt;Mit negativen Werten hier und positiven im &lt;b&gt;#START&lt;/b&gt;-Tag lässt sich ein kurzes Video nutzen.&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
         <source>Relative?</source>
         <translation>Relativ?</translation>
     </message>
@@ -6751,7 +6766,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Besitzt relative Zeitstempel.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
         <source>BPM</source>
         <translation>BPM</translation>
     </message>
@@ -6760,7 +6775,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Beats pro Minute</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
         <source>GAP</source>
         <translation>GAP</translation>
     </message>
@@ -6769,77 +6784,77 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Zeit bis zur ersten Silbe.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="185"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="187"/>
         <source>Indicate duplicate songs. &lt;b&gt;You should not see me.&lt;/b&gt;</source>
         <translation>Zeige doppelte Songs an. &lt;b&gt;Du solltest mich nicht sehen.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>, negated</source>
         <translation>, negiert</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="517"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="519"/>
         <source>Looking for duplicate songs...</source>
         <translation>Suche doppelte Songs...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="568"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
         <source>Filter applied. Duplicates for %1 songs found.</source>
         <translation>Filter angewendet. Duplikate für %1 songs gefunden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="572"/>
         <source>No duplicate songs found.</source>
         <translation>Keine doppelten Songs gefunden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="626"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="628"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="898"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="902"/>
         <source>%1 songs added to list of invisible songs.</source>
         <translation>%1 Songs wurden zur Liste der unsichtbaren Songs hinzugefügt.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1258"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1262"/>
         <source>Refreshing selected songs...</source>
         <translation>Aktualisiere ausgewählte Songs...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1336"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1340"/>
         <source>Show preview</source>
         <translation>Zeige Vorschau</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1337"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
         <source>Open image file externally</source>
         <translation>Öffne Bilddatei extern</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1339"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
         <source>Open video file externally</source>
         <translation>Öffne Videodatei extern</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1345"/>
         <source>Open audio file externally</source>
         <translation>Öffne Audiodatei extern</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1347"/>
         <source>Show file contents</source>
         <translation>Dateiinhalt anzeigen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1344"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1348"/>
         <source>Open text file externally</source>
         <translation>Öffne Textdatei extern</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1346"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1350"/>
         <source>Set as primary song</source>
         <translation>Als primären Song festlegen</translation>
     </message>
@@ -6848,12 +6863,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Öffnen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
         <source>Play</source>
         <translation>Abspielen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1362"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
         <source>Send To Playlist</source>
         <translation>An Playliste senden</translation>
     </message>
@@ -6862,103 +6877,103 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Cover von Amazon runterladen...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1365"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1369"/>
         <source>Review pictures</source>
         <translation>Bilder durchsehen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1370"/>
         <source>Covers...</source>
         <translation>Cover...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
         <source>Backgrounds...</source>
         <translation>Hintergründe...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="619"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
         <source>Hide</source>
         <translation>Verstecke</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
         <source>Selected Songs</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="624"/>
         <source>Selected Songs Only</source>
         <translation>Nur Auswahl</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
         <source>Unselected Songs</source>
         <translation>Negierte Auswahl</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="637"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="627"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1385"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
         <source>Show Lyrics...</source>
         <translation>Zeige Lyrics...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
         <source>Edit Lyrics...</source>
         <translation>Bearbeite Lyrics...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="636"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
         <source>Presets</source>
         <translation>Vorgaben</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="184"/>
         <source>Shows the gap between the beginning of the song and the first syllable.&lt;br&gt;&lt;i&gt;(in milliseconds)&lt;/i&gt;</source>
         <translation>Zeigt die Zeitspanne zwischen Beginn des Lieds und Beginn des Gesangs an.&lt;br&gt;&lt;i&gt;(in Millisekunden)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="640"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
         <source>Minimum</source>
         <translation>Minimum</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="643"/>
         <source>Spell &amp;&amp; File Checking</source>
         <translation>Bezeichner- &amp;&amp; Datei-Überprüfung</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="642"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="644"/>
         <source>Time Comparison</source>
         <translation>Zeitvergleich</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="646"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
         <source>Custom Tags</source>
         <translation>Benutzerdefinierte Song-Tags</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="856"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="860"/>
         <source>Hiding all visible songs...</source>
         <translation>Verstecke alle sichtbaren Songs...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="879"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
         <source>Could not hide any item.</source>
         <translation>Konnte nichts verstecken.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="887"/>
         <source>Hiding selected songs...</source>
         <translation>Verstecke ausgewählte Songs...</translation>
     </message>
@@ -6967,82 +6982,82 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">%1 Songs wurden versteckt.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="923"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="927"/>
         <source>%1 songs are visible now.</source>
         <translation>%1 Songs sind sichtbar.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="950"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="954"/>
         <source>All files in the song directory will be deleted including the directory itself if it is not empty.&lt;br&gt;&lt;br&gt;You want to delete the following &lt;b&gt;%1&lt;/b&gt; songs:</source>
         <translation>Alle Dateien im Song-Ordner werden gelöscht - auch der Ordner selbst, wenn er leer ist.&lt;br&gt;&lt;br&gt;Folgende &lt;b&gt;%1&lt;/b&gt; Songs werden gelöscht:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="963"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="967"/>
         <source>Delete Songs</source>
         <translation>Songs löschen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="965"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="969"/>
         <source>Delete these songs.</source>
         <translation>Diese Songs löschen.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="973"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="977"/>
         <source>Deleting selected songs...</source>
         <translation>Lösche ausgewählte Songs...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1165"/>
         <source>Including new songs to database...</source>
         <translation>Neue Songs werden integriert...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1179"/>
         <source>Invalid song file found: &quot;%1&quot;. Cannot include those.</source>
         <translation>Ungültige Songdatei: &quot;%1&quot;. Sowas kann nicht integriert werden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1238"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1242"/>
         <source>Could not create directory: &quot;%1&quot;. Disk full?</source>
         <translation>Verzeichnis konnte nicht erstellt werden: &quot;%1&quot;. Festplatte voll?</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1484"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1488"/>
         <source>You can only edit the lyrics of one song at a time.</source>
         <translation>Es können nur die Lyrics von einem Song gleichzeitig bearbeitet werden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1506"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1510"/>
         <source>Removing current filter...</source>
         <translation>Aktueller Filter wird entfernt...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>Filter applied: &quot;%1&quot;%2</source>
         <translation>Filter angewendet: &quot;%1&quot;%2</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1357"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1361"/>
         <source>Merge</source>
         <translation>Verbinden</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="650"/>
         <source>Types</source>
         <translation>Typen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="172"/>
         <source>Shows when the song playback stops.&lt;br&gt;&lt;i&gt;(in &lt;b&gt;milli&lt;/b&gt;seconds)&lt;/i&gt;</source>
         <translation>Zeigt an, zu welchem Zeitpunkt die Audiowiedergabe stoppt.&lt;br&gt;&lt;i&gt;(in &lt;b&gt;Milli&lt;/b&gt;sekunden)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="176"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="178"/>
         <source>Shows whether the song has relative timestamps.</source>
         <translation>Zeigt an, ob der Song relative Zeitstempel besitzt.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="181"/>
         <source>Shows the song tempo.&lt;br&gt;&lt;i&gt;(in beats per 15 seconds)</source>
         <translation>Zeigt das Songtempo an.&lt;br&gt;&lt;i&gt;(in Beats pro 15 Sekunden)</translation>
     </message>
@@ -7051,57 +7066,57 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Zeigt die Zeit zwischen Songanfang und der ersten Silbe an.&lt;br&gt;&lt;i&gt;(in Millisekunden)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1003"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1007"/>
         <source>Too few songs selected. You have to merge at least 2 songs.</source>
         <translation>Zu wenig Songs ausgewählt. Es müssen mindestens 2 Songs ausgewählt sein, um diese zu verbinden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1016"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1020"/>
         <source>You want to merge songs with &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. All files of the other songs will be moved to that song&apos;s path.&lt;br&gt;&lt;br&gt;The following &lt;b&gt;%3&lt;/b&gt; songs will disappear:</source>
         <translation>Die ausgewählten Songs sollen mit &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt; verbunden werden. Alle Dateien der anderen Songs werden in einen Ordner verschoben.&lt;br&gt;&lt;br&gt;Folgende &lt;b&gt;%3&lt;/b&gt; Songs werden verschwinden:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1029"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1033"/>
         <source>Merge Songs</source>
         <translation>Songs verbinden</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1031"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1035"/>
         <source>Merge these songs.</source>
         <translation>Diese Songs verbinden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1032"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1036"/>
         <source>Cancel merge operation.</source>
         <translation>Aktion abbrechen.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1039"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1043"/>
         <source>Merging selected songs with &quot;%1 - %2&quot;...</source>
         <translation>Verbinde ausgewählte Songs mit &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1060"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1064"/>
         <source>Could NOT copy file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Datei &quot;%1&quot; konnte nicht nach &quot;%2&quot; kopiert werden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1062"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1066"/>
         <source>File was copied successfully from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Die Datei &quot;%1&quot; wurde erfolgreich nach &quot;%2&quot; kopiert.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1071"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1075"/>
         <source>Not all files of &quot;%1 - %2&quot; were copied. Song will not be deleted. Merging failed.</source>
         <translation>Nicht alle Dateien von &quot;%1 - %2&quot; wurden kopiert. Song wird nicht gelöscht. Verbinden fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1184"/>
         <source>Cannot include license files as songs: &quot;%1&quot;</source>
         <translation>Lizenz-Dateien können nicht als Songs integriert werden: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
         <source>Get Covers...</source>
         <translation>Covers holen...</translation>
     </message>
@@ -7110,42 +7125,42 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Nachschauen bei Hitparade...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1474"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1478"/>
         <source>You can only display the lyrics of one song at a time.</source>
         <translation>Es können nur die Lyrics von einem Song gleichzeitig angezeigt werden.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
         <source>Speed</source>
         <translation>Tempo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
         <source>Shows the number of singable syllables per second. No freestyle or pauses included.</source>
         <translation>Zeigt die Anzahl der singbaren Silben pro Sekunde. Keine Freestyle-Noten oder Pausen berücksichtigt.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1375"/>
         <source>Calculate Song Speed</source>
         <translation>Tempo berechnen</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1380"/>
         <source>Open With Explorer...</source>
         <translation>Öffnen (mit Explorer)...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1384"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1388"/>
         <source>Find More From Artist</source>
         <translation>Finde mehr von Interpret</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="647"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="649"/>
         <source>Time &amp;&amp; Speed</source>
         <translation>Zeit &amp;&amp; Tempo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1085"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1089"/>
         <source>Calculate selected song speeds...</source>
         <translation>Berechne Tempo für ausgewählte Songs...</translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.es.ts
+++ b/src/resources/lang/UltraStar-Manager.es.ts
@@ -5194,32 +5194,32 @@ p, li { white-space: pre-wrap; }
         <translation>No se pudo abrir la canción: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="357"/>
+        <location filename="../../song/QUSongFile.cpp" line="367"/>
         <source>Deprecated tag information detected.</source>
         <translation>Se detectó información obsoleta en la etiqueta.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="358"/>
+        <location filename="../../song/QUSongFile.cpp" line="368"/>
         <source>The number of available tags in your configuration and that one this application offers are different.</source>
         <translation>El número de etiquetas disponibles en tu configuración y el que ofrece esta aplicación son diferentes.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="359"/>
+        <location filename="../../song/QUSongFile.cpp" line="369"/>
         <source>The tag order was reset to its default order. Check out the options to set up your custom order again.</source>
         <translation>El orden de etiquetas fue restablecido a su orden por defecto. Revisa las opciones para definir tu orden personalizado nuevamente.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="709"/>
+        <location filename="../../song/QUSongFile.cpp" line="719"/>
         <source>Save error! The song file &quot;%1&quot; was NOT saved.</source>
         <translation>¡Error al guardar! La canción &quot;%1&quot; NO fue guardada.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="228"/>
+        <location filename="../../song/QUSongFile.cpp" line="238"/>
         <source>Encoding mismatch. Defaulting to %1 for song file: &quot;%2&quot;</source>
         <translation>Incoherencia de codificación. Dejando por defecto %1 para la canción &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="233"/>
+        <location filename="../../song/QUSongFile.cpp" line="243"/>
         <source>&quot;%1&quot; unsupported. Defaulting to %2 for song file: &quot;%3&quot;</source>
         <translation>&quot;%1&quot; no está sportado. Dejando por defecto %2 para la canción &quot;%3&quot;</translation>
     </message>
@@ -5228,331 +5228,336 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">No es suficiente %1 como codificación de salida. Se usará UTF8 para la canción &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="768"/>
+        <location filename="../../song/QUSongFile.cpp" line="775"/>
         <source>The song file &quot;%1&quot; was saved successfully.</source>
         <translation>La canción &quot;%1&quot; fue guardada exitosamente.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="785"/>
+        <location filename="../../song/QUSongFile.cpp" line="792"/>
         <source>Old name and new name match: &quot;%1&quot;</source>
         <translation>El nombre antiguo y el nuevo coinciden: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="810"/>
+        <location filename="../../song/QUSongFile.cpp" line="817"/>
         <source>Could NOT rename the song directory &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo cambiar el nombre del directorio de canciones &quot;%1&quot; por &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="818"/>
+        <location filename="../../song/QUSongFile.cpp" line="825"/>
         <source>Song directory renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Cambió el nombre del directorio de canciones de: &quot;%1&quot; a: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="829"/>
+        <location filename="../../song/QUSongFile.cpp" line="836"/>
         <source>Could NOT rename the song file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo cambiar el nombre a la canción &quot;%1&quot; por &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="836"/>
+        <location filename="../../song/QUSongFile.cpp" line="843"/>
         <source>Song file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Se cambió el nombre de la canción de: &quot;%1&quot; por &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="848"/>
+        <location filename="../../song/QUSongFile.cpp" line="855"/>
         <source>Could NOT rename the audio file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo cambiar el nombre del archivo de audio &quot;%1&quot; por &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="853"/>
-        <location filename="../../song/QUSongFile.cpp" line="923"/>
+        <location filename="../../song/QUSongFile.cpp" line="860"/>
+        <location filename="../../song/QUSongFile.cpp" line="930"/>
         <source>Audio file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Se cambió el nombre del archivo de audio de: &quot;%1&quot; a: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="870"/>
+        <location filename="../../song/QUSongFile.cpp" line="877"/>
         <source>Could NOT rename the cover picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo cambiar el nombre de la carátula &quot;%1&quot; por &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="875"/>
-        <location filename="../../song/QUSongFile.cpp" line="901"/>
+        <location filename="../../song/QUSongFile.cpp" line="882"/>
+        <location filename="../../song/QUSongFile.cpp" line="908"/>
         <source>Cover picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Se cambió el nombre de la carátula de: &quot;%1&quot; a: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="892"/>
+        <location filename="../../song/QUSongFile.cpp" line="899"/>
         <source>Could NOT rename the background picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo cambiar el nombre de la imagen de fondo &quot;%1&quot; por &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="879"/>
-        <location filename="../../song/QUSongFile.cpp" line="897"/>
+        <location filename="../../song/QUSongFile.cpp" line="886"/>
+        <location filename="../../song/QUSongFile.cpp" line="904"/>
         <source>Background picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Se cambió el nombre de la imagen de fondo de: &quot;%1&quot; a: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="914"/>
+        <location filename="../../song/QUSongFile.cpp" line="921"/>
         <source>Could NOT rename the video file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo cambiar el nombre del video &quot;%1&quot; a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="857"/>
-        <location filename="../../song/QUSongFile.cpp" line="919"/>
+        <location filename="../../song/QUSongFile.cpp" line="864"/>
+        <location filename="../../song/QUSongFile.cpp" line="926"/>
         <source>Video file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Se cambió el nombre del video de: &quot;%1&quot; a: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="933"/>
+        <location filename="../../song/QUSongFile.cpp" line="940"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for artist.</source>
         <translation>La canción &quot;%1 . %2&quot; no tiene un archivo de audio asignado. No se puede usar la etiqueta ID3 para el artista.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="944"/>
+        <location filename="../../song/QUSongFile.cpp" line="951"/>
         <source>The audio file %1 does not contain ID3 tag information about an artist.</source>
         <translation>El archivo de audio %1 no tiene información de artista en su etiqueta ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="949"/>
+        <location filename="../../song/QUSongFile.cpp" line="956"/>
         <source>ID3 tag of &quot;%1&quot; used for artist. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Se usó la etiqueta ID3 de &quot;%1&quot; para el artista. Fue cambiado de: &quot;%2&quot; a &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="954"/>
+        <location filename="../../song/QUSongFile.cpp" line="961"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for title.</source>
         <translation>La canción &quot;%1 . %2&quot; no tiene un archivo de audio asignado. No se puede usar la etiqueta ID3 para el título.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="964"/>
+        <location filename="../../song/QUSongFile.cpp" line="971"/>
         <source>The audio file %1 does not contain ID3 tag information about a title.</source>
         <translation>El archivo de audio %1 no tiene información de título en su etiqueta ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="969"/>
+        <location filename="../../song/QUSongFile.cpp" line="976"/>
         <source>ID3 tag of &quot;%1&quot; used for title. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Se usó la etiqueta ID3 de &quot;%1&quot; para el título. Fue cambiado de: &quot;%2&quot; a &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="974"/>
+        <location filename="../../song/QUSongFile.cpp" line="981"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for genre.</source>
         <translation>La canción &quot;%1 . %2&quot; no tiene un archivo de audio asignado. No se puede usar la etiqueta ID3 para el género.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="984"/>
+        <location filename="../../song/QUSongFile.cpp" line="991"/>
         <source>The audio file %1 does not contain ID3 tag information about a genre.</source>
         <translation>El archivo de audio %1 no tiene información de género en su etiqueta ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="989"/>
+        <location filename="../../song/QUSongFile.cpp" line="996"/>
         <source>ID3 tag of &quot;%1&quot; used for genre. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Se usó la etiqueta ID3 de &quot;%1&quot; para el género. Fue cambiado de: &quot;%2&quot; a &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="994"/>
+        <location filename="../../song/QUSongFile.cpp" line="1001"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for year.</source>
         <translation>La canción &quot;%1 . %2&quot; no tiene un archivo de audio asignado. No se puede usar la etiqueta ID3 para el año.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1004"/>
+        <location filename="../../song/QUSongFile.cpp" line="1011"/>
         <source>The audio file %1 does not contain ID3 tag information about a year.</source>
         <translation>El archivo de audio %1 no tiene información de año en su etiqueta ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1009"/>
+        <location filename="../../song/QUSongFile.cpp" line="1016"/>
         <source>ID3 tag of &quot;%1&quot; used for year. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Se usó la etiqueta ID3 de &quot;%1&quot; para el año. Fue cambiado de: &quot;%2&quot; a &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1014"/>
+        <location filename="../../song/QUSongFile.cpp" line="1021"/>
         <source>The song &quot;%1 - %2&quot; has no unsupported tags.</source>
         <translation>La canción &quot;%1 - %2&quot; no tiene etiquetas no soportadas.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1022"/>
+        <location filename="../../song/QUSongFile.cpp" line="1029"/>
         <source>Unsupported tag removed: #%1.</source>
         <translation>Etiqueta no soportada fue eliminada: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1024"/>
+        <location filename="../../song/QUSongFile.cpp" line="1031"/>
         <source>Unsupported tag skipped: #%1.</source>
         <translation>Etiqueta no soportada fue omitida: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1045"/>
+        <location filename="../../song/QUSongFile.cpp" line="1052"/>
         <source>Assigned &quot;%1&quot; as audio file for &quot;%2 - %3&quot;.</source>
         <translation>Se asignó &quot;%1&quot; como archivo de audio para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1040"/>
+        <location filename="../../song/QUSongFile.cpp" line="1047"/>
         <source>Assigned &quot;%1&quot; as video file for &quot;%2 - %3&quot;.</source>
         <translation>Se asignó &quot;%1&quot; como archivo de video para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="204"/>
+        <location filename="../../song/QUSongFile.cpp" line="198"/>
+        <source>Failed to detect line endings in file &quot;%1&quot;, defaulting to CRLF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../song/QUSongFile.cpp" line="214"/>
         <source>UTF8 detected in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="217"/>
+        <location filename="../../song/QUSongFile.cpp" line="227"/>
         <source>ENCODING:CP1252 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="222"/>
+        <location filename="../../song/QUSongFile.cpp" line="232"/>
         <source>ENCODING:CP1250 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="242"/>
+        <location filename="../../song/QUSongFile.cpp" line="252"/>
         <source>Not a valid UTF8 file and ENCODING tag missing. Defaulting to %1 in song file: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1053"/>
+        <location filename="../../song/QUSongFile.cpp" line="1060"/>
         <source>Assigned &quot;%1&quot; as cover picture for &quot;%2 - %3&quot;.</source>
         <translation>Se asignó &quot;%1&quot; como carátula para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1056"/>
+        <location filename="../../song/QUSongFile.cpp" line="1063"/>
         <source>Assigned &quot;%1&quot; as background picture for &quot;%2 - %3&quot;.</source>
         <translation>Se asignó &quot;%1&quot; como imagen de fondo para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1071"/>
+        <location filename="../../song/QUSongFile.cpp" line="1078"/>
         <source>Could not copy the file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo copiar el archivo &quot;%1&quot; a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1075"/>
+        <location filename="../../song/QUSongFile.cpp" line="1082"/>
         <source>The file &quot;%1&quot; was successfully copied to &quot;%2&quot;.</source>
         <translation>El archivo &quot;%1&quot; fue copiado exitosamente a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1107"/>
+        <location filename="../../song/QUSongFile.cpp" line="1114"/>
         <source>File removed successfully: &quot;%1&quot;.</source>
         <translation>Archivo removido exitosamente: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1109"/>
+        <location filename="../../song/QUSongFile.cpp" line="1116"/>
         <source>File COULD NOT be removed: &quot;%1&quot;.</source>
         <translation>No se pudo remover el archivo &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1120"/>
+        <location filename="../../song/QUSongFile.cpp" line="1127"/>
         <source>Audio file tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta de archivo de audio removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1124"/>
+        <location filename="../../song/QUSongFile.cpp" line="1131"/>
         <source>Cover tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta de carátula removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1128"/>
+        <location filename="../../song/QUSongFile.cpp" line="1135"/>
         <source>Background tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta de imagen de fondo removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1133"/>
+        <location filename="../../song/QUSongFile.cpp" line="1140"/>
         <source>Video tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta de video removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1147"/>
+        <location filename="../../song/QUSongFile.cpp" line="1154"/>
         <source>Old path and new path match! Cannot change song path to: &quot;%1&quot;</source>
         <translation>¡Las rutas de acceso antigua y nueva coinciden! No se puede cambiar la ruta de acceso para: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1152"/>
+        <location filename="../../song/QUSongFile.cpp" line="1159"/>
         <source>Could not create new song path: &quot;%1&quot;</source>
         <translation>No se pudo crear una nueva ruta de acceso: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1166"/>
+        <location filename="../../song/QUSongFile.cpp" line="1173"/>
         <source>Failed to move &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo mover &quot;%1&quot; a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1169"/>
+        <location filename="../../song/QUSongFile.cpp" line="1176"/>
         <source>The file &quot;%1&quot; was successfully moved to &quot;%2&quot;.</source>
         <translation>El archivo &quot;%1&quot; fue movido exitosamente a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1173"/>
+        <location filename="../../song/QUSongFile.cpp" line="1180"/>
         <source>Could NOT move all files of the song &quot;%2&quot; to a new location. Check out &quot;%1&quot; for the files which were copied.</source>
         <translation>No se pudieron mover todos los archivos de la canción &quot;%2&quot; a una nueva ubicación. Revisa en &quot;%1&quot; qué archivos fueron copiados.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1183"/>
+        <location filename="../../song/QUSongFile.cpp" line="1190"/>
         <source>Could not remove old, empty folder &quot;%1&quot;. Please do it manually.</source>
         <translation>No se pudo eliminar la carpeta antigua y vacía &quot;%1&quot;. Por favor, hazlo manualmente.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1190"/>
+        <location filename="../../song/QUSongFile.cpp" line="1197"/>
         <source>Location of song &quot;%1 - %2&quot; successfully changed to &quot;%3&quot; in your UltraStar song folder.</source>
         <translation>La ubicación de la canción &quot;%1 - %2&quot; cambió exitosamente a &quot;%3&quot; en tu carpeta de canciones de UltraStar.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1201"/>
+        <location filename="../../song/QUSongFile.cpp" line="1208"/>
         <source>Could not fix audio length because no audio file is present: &quot;%1 - %2&quot;</source>
         <translation>No se pudo arreglar la duración del audio porque no hay un archivo de audio: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1212"/>
+        <location filename="../../song/QUSongFile.cpp" line="1219"/>
         <source>Could not fix audio length because audio file is shorter than song: &quot;%1 - %2&quot;</source>
         <translation>No se pudo arreglar la duración del audio porque el archivo de audio es más corto que la canción: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1219"/>
+        <location filename="../../song/QUSongFile.cpp" line="1226"/>
         <source>Could not fix audio length because new value for #END would be greater than length of audio file: &quot;%1 - %2&quot;</source>
         <translation>No se pudo arreglar la duración del audio porque el nuevo valor para #END seria más grande que la duración del archivo de audio: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1226"/>
+        <location filename="../../song/QUSongFile.cpp" line="1233"/>
         <source>Audio length was fixed for song &quot;%1 - %2&quot;. #END changed to: %3</source>
         <translation>Duración del audio fue arreglada para la canción &quot;%1 - %2&quot;. #END cambió a: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1241"/>
+        <location filename="../../song/QUSongFile.cpp" line="1248"/>
         <source>#GAP changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>#GAP cambió de %1 a %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1250"/>
+        <location filename="../../song/QUSongFile.cpp" line="1257"/>
         <source>The tag #END was removed for: &quot;%1 - %2&quot;</source>
         <translation>La etiqueta #END fue removida para: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1262"/>
+        <location filename="../../song/QUSongFile.cpp" line="1269"/>
         <source>INCONSISTENT STATE! The song &quot;%1 - %2&quot; has unsaved changes and its persistent song file &quot;%3&quot; was modified externally. Save your changes or rebuild the tree manually.</source>
         <translation>¡ESTADO INCONSISTENTE! La canción &quot;%1 - %2&quot; tiene cambios no guardados y su archivo &quot;%3&quot; fue modificado externamente. Guarda tus cambios o actualiza el árbol manualmente.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1268"/>
+        <location filename="../../song/QUSongFile.cpp" line="1275"/>
         <source>Song file changed: &quot;%1&quot;</source>
         <translation>Canción modificada: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1444"/>
+        <location filename="../../song/QUSongFile.cpp" line="1451"/>
         <source>Primary song file changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Canción primaria cambió de &quot;%1&quot; a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1508"/>
+        <location filename="../../song/QUSongFile.cpp" line="1515"/>
         <source>Error while preparing lyrics for %1 - %2. Could not parse the following line: %3</source>
         <translation>Error al preparar la letra para %1 - %2. No se pudo analizar la línea: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1521"/>
+        <location filename="../../song/QUSongFile.cpp" line="1528"/>
         <source>Error while preparing lyrics for %1 - %2. Songs may not start with a line break.</source>
         <translation>Error al preparar la letra para %1 - %2. Las canciones no pueden comenzar con un salto de línea.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1545"/>
+        <location filename="../../song/QUSongFile.cpp" line="1552"/>
         <source>Line too short: &quot;%1&quot;</source>
         <translation>Línea muy corta: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1601"/>
+        <location filename="../../song/QUSongFile.cpp" line="1608"/>
         <source>More than one score file found for &quot;%1 - %2&quot;. Only one will be used.</source>
         <translation>Se encontró más de un archivo de puntajes para &quot;%1 - %2&quot;. Solo se usará uno.</translation>
     </message>
@@ -5764,7 +5769,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="144"/>
+        <source>Line Endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../songtree/QUSongTree.cpp" line="145"/>
+        <source>Shows whether the text file has CRLF or LF line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
         <source>Song</source>
         <translation>Canción</translation>
     </message>
@@ -5773,12 +5788,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Duración de la canción calculada del BPM y la letra.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="150"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="152"/>
         <source>Indicates a problem with the difference of &lt;i&gt;song length&lt;/i&gt; and &lt;i&gt;audio length&lt;/i&gt;.&lt;br&gt;&lt;br&gt;The tooltip shows the difference.</source>
         <translation>Indica un problema con la diferencia entre &lt;i&gt;la duración de la canción&lt;/i&gt; y &lt;i&gt;la duración del audio&lt;/i&gt;.&lt;br&gt;&lt;br&gt;El globo de sugerencia muestra la diferencia.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="153"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
         <source>Audio</source>
         <translation>Pista de Audio</translation>
     </message>
@@ -5795,17 +5810,17 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Muestra la duración efectiva:&lt;br&gt;&lt;b&gt;duración del audio - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
         <source>Shows the number of singable syllables per second. No freestyle or pauses included.</source>
         <translation>Muestra el número de sílabas cantables por segundo. No inlcuye pausas ni modos libres.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
@@ -5814,7 +5829,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Omite los primeros segundos de la canción.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="168"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
         <source>End</source>
         <translation>End</translation>
     </message>
@@ -5823,7 +5838,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Restablece la duración del archivo de audio.&lt;br&gt;&lt;i&gt;(en milisegundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="171"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
         <source>Videogap</source>
         <translation>Videogap</translation>
     </message>
@@ -5832,7 +5847,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Omite los primeros segundos de video.&lt;br&gt;&lt;br&gt;&lt;i&gt;Usa valores negativos aquí con valores positivos en &lt;b&gt;#START&lt;/b&gt; para corregir un archivo de video muy corto.&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="169"/>
         <source>Shows how much time is skipped from the beginning of the audio file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Muestra cuánto tiempo se salta desde el principio del archivo de audio.&lt;br&gt;&lt;i&gt;(en segundos)&lt;/i&gt;</translation>
     </message>
@@ -5841,12 +5856,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Muestra cuánto tiempo se salta desde el final del archivo de audio.&lt;br&gt;&lt;i&gt;(en milisegundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
         <source>Shows how much time is skipped from the video file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Muestra cuánto tiempo se salta del archivo de video.&lt;br&gt;&lt;i&gt;(en segundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
         <source>Relative?</source>
         <translation>¿Relativas?</translation>
     </message>
@@ -5855,7 +5870,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Muestra si los marcadores de tiempo son relativos.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
         <source>BPM</source>
         <translation>BPM</translation>
     </message>
@@ -5864,7 +5879,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Beats por minuto</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
         <source>GAP</source>
         <translation>GAP</translation>
     </message>
@@ -5873,495 +5888,495 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Tiempo hasta la primera sílaba.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="149"/>
         <source>Shows the song length calculated from BPM and lyrics.</source>
         <translation>Muestra la duración de la canción calculada desde el BPM y la letra.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
         <source>Shows the length of audio file, if present.&lt;br&gt;&lt;br&gt;Can be reset through &lt;b&gt;#END&lt;/b&gt; tag.</source>
         <translation>Muestra la duración de la pista de audio, si existe.&lt;br&gt;&lt;br&gt;Puede restablecerse con la etiqueta &lt;b&gt;#END&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
         <source>Effective</source>
         <translation>Efectivo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
         <source>Shows the effective song length:&lt;br&gt;&lt;b&gt;audio length - #START&lt;/b&gt;.</source>
         <translation>Muestra la duración efectiva de la canción:&lt;br&gt;&lt;b&gt;duración del audio - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="172"/>
         <source>Shows when the song playback stops.&lt;br&gt;&lt;i&gt;(in &lt;b&gt;milli&lt;/b&gt;seconds)&lt;/i&gt;</source>
         <translation>Muestra cuándo finaliza la reproducción de la canción.&lt;br&gt;&lt;i&gt;(en &lt;b&gt;mili&lt;/b&gt;segundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="176"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="178"/>
         <source>Shows whether the song has relative timestamps.</source>
         <translation>Muestra si la canción tiene marcadores de tiempo relativos.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="181"/>
         <source>Shows the song tempo.&lt;br&gt;&lt;i&gt;(in beats per 15 seconds)</source>
         <translation>Muestra el tempo de la canción.&lt;br&gt;&lt;i&gt;(en beats por cada 15 segundos)</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="184"/>
         <source>Shows the gap between the beginning of the song and the first syllable.&lt;br&gt;&lt;i&gt;(in milliseconds)&lt;/i&gt;</source>
         <translation>Muestra el espacio entre el principio de la canción y la primera sílaba.&lt;br&gt;&lt;i&gt;(en milisegundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="185"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="187"/>
         <source>Indicate duplicate songs. &lt;b&gt;You should not see me.&lt;/b&gt;</source>
         <translation>Indica las canciones duplicadas. &lt;b&gt;No debieras verme.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="323"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="325"/>
         <source>Saving unsaved changes...</source>
         <translation>Guardando cambios...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="394"/>
         <source>Filter removed. All songs are visible now.</source>
         <translation>Filtro quitado. Ahora todas las canciones son visibles.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="404"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="406"/>
         <source>Applying filter...</source>
         <translation>Aplicando filtro...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>Filter applied: &quot;%1&quot;%2</source>
         <translation>Filtro aplicado: &quot;%1&quot;%2</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>, negated</source>
         <translation>, negado</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="517"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="519"/>
         <source>Looking for duplicate songs...</source>
         <translation>Buscando canciones duplicadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="568"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
         <source>Filter applied. Duplicates for %1 songs found.</source>
         <translation>Filtro aplicado. Se encontraron duplicados para %1 canciones.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="572"/>
         <source>No duplicate songs found.</source>
         <translation>No se encontraron canciones duplicadas.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="619"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
         <source>Hide</source>
         <translation>Ocultar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
         <source>Selected Songs</source>
         <translation>Canciones Seleccionadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="624"/>
         <source>Selected Songs Only</source>
         <translation>Solo Canciones Seleccionadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
         <source>Unselected Songs</source>
         <translation>Canciones No Seleccionadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="637"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="627"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
         <source>All</source>
         <translation>Todas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="626"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="628"/>
         <source>None</source>
         <translation>Ninguna</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="636"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
         <source>Presets</source>
         <translation>Prestablecidas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="640"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
         <source>Minimum</source>
         <translation>Mínimas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="643"/>
         <source>Spell &amp;&amp; File Checking</source>
         <translation>Nombres y validación de archivos</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="642"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="644"/>
         <source>Time Comparison</source>
         <translation>Comparación de Tiempo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="646"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
         <source>Custom Tags</source>
         <translation>Etiquetas Personalizadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="647"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="649"/>
         <source>Time &amp;&amp; Speed</source>
         <translation>Tiempo &amp;&amp; Velocidad</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="650"/>
         <source>Types</source>
         <translation>Tipos</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="856"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="860"/>
         <source>Hiding all visible songs...</source>
         <translation>Ocultando todas las canciones visibles...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="879"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
         <source>Could not hide any item.</source>
         <translation>No se pudo ocultar ningún ítem.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="887"/>
         <source>Hiding selected songs...</source>
         <translation>Ocultado canciones seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="898"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="902"/>
         <source>%1 songs added to list of invisible songs.</source>
         <translation>%1 canciones agregadas a la lista de canciones ocultas.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="923"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="927"/>
         <source>%1 songs are visible now.</source>
         <translation>%1 canciones son visibles ahora.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="950"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="954"/>
         <source>All files in the song directory will be deleted including the directory itself if it is not empty.&lt;br&gt;&lt;br&gt;You want to delete the following &lt;b&gt;%1&lt;/b&gt; songs:</source>
         <translation>Todos los archivos en este directorio de canciones serán eliminados, incluyendo el directorio mismo si no está vacío.&lt;br&gt;&lt;br&gt;Quieres eliminar las siguientes &lt;b&gt;%1&lt;/b&gt; canciones:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="963"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="967"/>
         <source>Delete Songs</source>
         <translation>Eliminar Canciones</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="965"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="969"/>
         <source>Delete these songs.</source>
         <translation>Eliminar estas canciones.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="966"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1430"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="970"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1434"/>
         <source>Cancel delete operation.</source>
         <translation>Cancelar operación de eliminación.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="973"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="977"/>
         <source>Deleting selected songs...</source>
         <translation>Eliminando canciones seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1003"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1007"/>
         <source>Too few songs selected. You have to merge at least 2 songs.</source>
         <translation>Muy pocas canciones seleccionadas. Tienes que fusionar al menos dos canciones.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1016"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1020"/>
         <source>You want to merge songs with &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. All files of the other songs will be moved to that song&apos;s path.&lt;br&gt;&lt;br&gt;The following &lt;b&gt;%3&lt;/b&gt; songs will disappear:</source>
         <translation>Quieres fusionar canciones con &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. Todos los archivos de las demás canciones serán movidos a la ruta de acceso de esa canción.&lt;br&gt;&lt;br&gt;Las siguientes &lt;b&gt;%3&lt;/b&gt; canciones desaparecerán:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1029"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1033"/>
         <source>Merge Songs</source>
         <translation>Fusionar Canciones</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1031"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1035"/>
         <source>Merge these songs.</source>
         <translation>Fusiona estas canciones.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1032"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1036"/>
         <source>Cancel merge operation.</source>
         <translation>Cancelar operación de fusión.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1039"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1043"/>
         <source>Merging selected songs with &quot;%1 - %2&quot;...</source>
         <translation>Fusionando canciones seleccionadas con &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1060"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1064"/>
         <source>Could NOT copy file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>No se pudo copiar el archivo &quot;%1&quot; a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1062"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1066"/>
         <source>File was copied successfully from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Archivo fue copiado exitosamente desde &quot;%1&quot; a &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1071"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1075"/>
         <source>Not all files of &quot;%1 - %2&quot; were copied. Song will not be deleted. Merging failed.</source>
         <translation>No todos los archivos de &quot;%1 - %2&quot; fueron copiados. La canción no será eliminada. Falló la fusión.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1085"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1089"/>
         <source>Calculate selected song speeds...</source>
         <translation>Calculando velocidad de canciones seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1106"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1110"/>
         <source>Calculating selected song ReplayGain...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1121"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1125"/>
         <source>Copy Files</source>
         <translation>Copiar Archivos</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1122"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1126"/>
         <source>You want to copy &lt;b&gt;%1&lt;/b&gt; files to &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</source>
         <translation>Quieres copiar &lt;b&gt;%1&lt;/b&gt; archivos a &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1123"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1127"/>
         <source>Copy these files.</source>
         <translation>Copiar estos archivos.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1124"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1128"/>
         <source>Cancel copy operation.</source>
         <translation>Cancelar operación de copiado.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1131"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1135"/>
         <source>Copy &amp; Use files for the song: &quot;%1 - %2&quot;...</source>
         <translation>Copiar y usar los archivos para la canción: &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1165"/>
         <source>Including new songs to database...</source>
         <translation>Incluyendo nuevas canciones a la base de datos...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1179"/>
         <source>Invalid song file found: &quot;%1&quot;. Cannot include those.</source>
         <translation>Se encontró un archivo de canción inválido: &quot;%1&quot;. No se pueden incluir esos.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1184"/>
         <source>Cannot include license files as songs: &quot;%1&quot;</source>
         <translation>No se pueden incluir archivos de licencia como canciones: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1191"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1195"/>
         <source>Could not copy song file &quot;%1&quot; to new song directory &quot;%2&quot;!</source>
         <translation>¡No se pudo copiar la canción &quot;%1&quot; al nuevo directorio de canciones &quot;%2&quot;!</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1199"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1203"/>
         <source>New song included to your song collection: &quot;%1 - %2&quot;.</source>
         <translation>Se incluyó una nueva canción a tu colección: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1238"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1242"/>
         <source>Could not create directory: &quot;%1&quot;. Disk full?</source>
         <translation>No se puede crear el directorio: &quot;%1&quot;. ¿Disco lleno?</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1258"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1262"/>
         <source>Refreshing selected songs...</source>
         <translation>Actualizando canciones seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1303"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1307"/>
         <source>Saving selected songs...</source>
         <translation>Guardando canciones seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1336"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1340"/>
         <source>Show preview</source>
         <translation>Mostrar previsualización</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1337"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
         <source>Open image file externally</source>
         <translation>Abrir imagen externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1339"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
         <source>Open video file externally</source>
         <translation>Abrir video externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1345"/>
         <source>Open audio file externally</source>
         <translation>Abrir audio externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1347"/>
         <source>Show file contents</source>
         <translation>Mostrar contenido del archivo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1344"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1348"/>
         <source>Open text file externally</source>
         <translation>Abrir archivo de texto externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1346"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1350"/>
         <source>Set as primary song</source>
         <translation>Establecer como canción primaria</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1349"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1353"/>
         <source>Open externally</source>
         <translation>Abrir externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1351"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1356"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1360"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1354"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1358"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1357"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1361"/>
         <source>Merge</source>
         <translation>Fusionar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
         <source>Play</source>
         <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1362"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
         <source>Send To Playlist</source>
         <translation>Enviar a Lista de Reproducción</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
         <source>Get Covers...</source>
         <translation>Obtener Carátulas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1365"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1369"/>
         <source>Review pictures</source>
         <translation>Revisar imágenes</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1370"/>
         <source>Covers...</source>
         <translation>Carátulas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
         <source>Backgrounds...</source>
         <translation>Imágenes de fondo...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1375"/>
         <source>Calculate Song Speed</source>
         <translation>Calcular Velocidad de la Canción</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1372"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
         <source>Calculate Song ReplayGain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1380"/>
         <source>Open With Explorer...</source>
         <translation>Abrir con el Explorador...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1379"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1383"/>
         <source>Open With Finder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1382"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
         <source>Open With File Manager...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1384"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1388"/>
         <source>Find More From Artist</source>
         <translation>Buscar más del artista</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1385"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
         <source>Show Lyrics...</source>
         <translation>Mostrar Letra...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
         <source>Edit Lyrics...</source>
         <translation>Editar Letra...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
         <source>Search for cover on AlbumArtExchange...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
         <source>Search for cover on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1391"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
         <source>Search for artwork on Fanart...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
         <source>Search for background on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1397"/>
         <source>Search for video on Google Video...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1398"/>
         <source>Search for video on Youtube...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1399"/>
         <source>Look up on Hitparade.ch...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6370,64 +6385,64 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Buscar en Hitparade...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
         <source>Look up on USDB...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1404"/>
         <source>Create Duet From Song Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1427"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1431"/>
         <source>Delete File</source>
         <translation>Eliminar Archivo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1428"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1432"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; will be deleted permanently. You cannot undo a delete operation.</source>
         <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; será eliminado permanentemente. No puedes deshacer una operación de eliminación.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1429"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1433"/>
         <source>Delete this file.</source>
         <translation>Eliminar este archivo.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1435"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1439"/>
         <source>The file &quot;%1&quot; was deleted successfully.</source>
         <translation>El archivo &quot;%1&quot; fue eliminado exitosamente.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1437"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1441"/>
         <source>The file &quot;%1&quot; was NOT deleted.</source>
         <translation>El archivo &quot;%1&quot; NO fue eliminado.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1474"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1478"/>
         <source>You can only display the lyrics of one song at a time.</source>
         <translation>Solo puedes mostrar la letra de una canción a la vez.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1484"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1488"/>
         <source>You can only edit the lyrics of one song at a time.</source>
         <translation>Solo puedes editar la letra de una canción a la vez.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1506"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1510"/>
         <source>Removing current filter...</source>
         <translation>Quitando filtro actual...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1570"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1595"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1618"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1641"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1664"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1686"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1706"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1728"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1574"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1599"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1645"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1668"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1690"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1710"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1732"/>
         <source>You can only look up one song at a time.</source>
         <translation>Solo puedes buscar una canción a la vez.</translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.fr.ts
+++ b/src/resources/lang/UltraStar-Manager.fr.ts
@@ -5402,22 +5402,22 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Utilisation de l&apos;encodage par défaut CP1252 pour la chanson: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="357"/>
+        <location filename="../../song/QUSongFile.cpp" line="367"/>
         <source>Deprecated tag information detected.</source>
         <translation>Champ obsolète détecté.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="358"/>
+        <location filename="../../song/QUSongFile.cpp" line="368"/>
         <source>The number of available tags in your configuration and that one this application offers are different.</source>
         <translation>Le nombre de champs disponibles dans votre configuration et celui que cette application propose sont différents.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="359"/>
+        <location filename="../../song/QUSongFile.cpp" line="369"/>
         <source>The tag order was reset to its default order. Check out the options to set up your custom order again.</source>
         <translation>L&apos;ordre des champs à été réinitialisé à son ordre par défaut. Regardez dans les options pour rerégler votre ordre personnalisé.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="709"/>
+        <location filename="../../song/QUSongFile.cpp" line="719"/>
         <source>Save error! The song file &quot;%1&quot; was NOT saved.</source>
         <translation>Erreur de sauvegarde! La chanson &quot;%1&quot; n&apos;a PAS été sauvé.</translation>
     </message>
@@ -5430,12 +5430,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">L&apos;encodage ne correspond pas! Utilisation de l&apos;UTF8 pour l&apos;encodage de la chanson: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="228"/>
+        <location filename="../../song/QUSongFile.cpp" line="238"/>
         <source>Encoding mismatch. Defaulting to %1 for song file: &quot;%2&quot;</source>
         <translation>L&apos;encodage ne correspond pas. Utilisation de l&apos;encodage %1 pour la chanson: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="233"/>
+        <location filename="../../song/QUSongFile.cpp" line="243"/>
         <source>&quot;%1&quot; unsupported. Defaulting to %2 for song file: &quot;%3&quot;</source>
         <translation>&quot;%1&quot; non-supporté. Mise par défaut en %2 pour la chanson: &quot;%3&quot;</translation>
     </message>
@@ -5444,331 +5444,336 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">%1 encodage de sortie non-suffisant. Utilisation de l&apos;UTF8 pour la chanson: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="768"/>
+        <location filename="../../song/QUSongFile.cpp" line="775"/>
         <source>The song file &quot;%1&quot; was saved successfully.</source>
         <translation>La chanson &quot;%1&quot; a été sauvegardé avec succès.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="785"/>
+        <location filename="../../song/QUSongFile.cpp" line="792"/>
         <source>Old name and new name match: &quot;%1&quot;</source>
         <translation>L&apos;ancien nom et le nouveau nom correspondent: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="810"/>
+        <location filename="../../song/QUSongFile.cpp" line="817"/>
         <source>Could NOT rename the song directory &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>IMPOSSIBLE de renommer le dossier de chanson de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="818"/>
+        <location filename="../../song/QUSongFile.cpp" line="825"/>
         <source>Song directory renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Dossier de chanson renommé de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="829"/>
+        <location filename="../../song/QUSongFile.cpp" line="836"/>
         <source>Could NOT rename the song file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>IMPOSSIBLE de renommer le fichier de la chanson de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="836"/>
+        <location filename="../../song/QUSongFile.cpp" line="843"/>
         <source>Song file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Fichier de la chanson renommé de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="848"/>
+        <location filename="../../song/QUSongFile.cpp" line="855"/>
         <source>Could NOT rename the audio file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>IMPOSSIBLE de renommer le fichier audio de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="853"/>
-        <location filename="../../song/QUSongFile.cpp" line="923"/>
+        <location filename="../../song/QUSongFile.cpp" line="860"/>
+        <location filename="../../song/QUSongFile.cpp" line="930"/>
         <source>Audio file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Fichier audio renommé de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="870"/>
+        <location filename="../../song/QUSongFile.cpp" line="877"/>
         <source>Could NOT rename the cover picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>IMPOSSIBLE de renommer le fichier de couverture de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="875"/>
-        <location filename="../../song/QUSongFile.cpp" line="901"/>
+        <location filename="../../song/QUSongFile.cpp" line="882"/>
+        <location filename="../../song/QUSongFile.cpp" line="908"/>
         <source>Cover picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Fichier de la couverutre renommé de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="892"/>
+        <location filename="../../song/QUSongFile.cpp" line="899"/>
         <source>Could NOT rename the background picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>IMPOSSIBLE de renommer le fichier de fond d&apos;écran de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="879"/>
-        <location filename="../../song/QUSongFile.cpp" line="897"/>
+        <location filename="../../song/QUSongFile.cpp" line="886"/>
+        <location filename="../../song/QUSongFile.cpp" line="904"/>
         <source>Background picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Fichier de fond d&apos;écran renommé de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="914"/>
+        <location filename="../../song/QUSongFile.cpp" line="921"/>
         <source>Could NOT rename the video file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>IMPOSSIBLE de renommer le fichier vidéo de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="857"/>
-        <location filename="../../song/QUSongFile.cpp" line="919"/>
+        <location filename="../../song/QUSongFile.cpp" line="864"/>
+        <location filename="../../song/QUSongFile.cpp" line="926"/>
         <source>Video file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Fichier vidéo renommé de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="933"/>
+        <location filename="../../song/QUSongFile.cpp" line="940"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for artist.</source>
         <translation>La chanson &quot;%1 - %2&quot; n&apos;a pas de fichier audio. Impossible d&apos;utiliser l&apos;ID3 pour l&apos;artiste.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="944"/>
+        <location filename="../../song/QUSongFile.cpp" line="951"/>
         <source>The audio file %1 does not contain ID3 tag information about an artist.</source>
         <translation>Le fichier audio %1 ne contient pas d&apos;information concernant l&apos;artiste dans l&apos;ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="949"/>
+        <location filename="../../song/QUSongFile.cpp" line="956"/>
         <source>ID3 tag of &quot;%1&quot; used for artist. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>L&apos;ID3 de &quot;%1&quot;a été utilisé pour l&apos;artiste. Changement de : &quot;%2&quot; en &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="954"/>
+        <location filename="../../song/QUSongFile.cpp" line="961"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for title.</source>
         <translation>La chanson &quot;%1 - %2&quot; n&apos;a pas de fichier audio. Impossible d&apos;utiliser l&apos;ID3 pour le titre.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="964"/>
+        <location filename="../../song/QUSongFile.cpp" line="971"/>
         <source>The audio file %1 does not contain ID3 tag information about a title.</source>
         <translation>Le fichier audio %1 ne contient pas d&apos;information concernant le titre dans l&apos;ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="969"/>
+        <location filename="../../song/QUSongFile.cpp" line="976"/>
         <source>ID3 tag of &quot;%1&quot; used for title. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>L&apos;ID3 de &quot;%1&quot;a été utilisé pour le titre. Changement de : &quot;%2&quot; en &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="974"/>
+        <location filename="../../song/QUSongFile.cpp" line="981"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for genre.</source>
         <translation>La chanson &quot;%1 - %2&quot; n&apos;a pas de fichier audio. Impossible d&apos;utiliser l&apos;ID3 pour le genre.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="984"/>
+        <location filename="../../song/QUSongFile.cpp" line="991"/>
         <source>The audio file %1 does not contain ID3 tag information about a genre.</source>
         <translation>Le fichier audio %1 ne contient pas d&apos;information concernant le genre dans l&apos;ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="989"/>
+        <location filename="../../song/QUSongFile.cpp" line="996"/>
         <source>ID3 tag of &quot;%1&quot; used for genre. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>L&apos;ID3 de &quot;%1&quot;a été utilisé pour le genre. Changement de : &quot;%2&quot; en &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="994"/>
+        <location filename="../../song/QUSongFile.cpp" line="1001"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for year.</source>
         <translation>La chanson &quot;%1 - %2&quot; n&apos;a pas de fichier audio. Impossible d&apos;utiliser l&apos;ID3 pour l&apos;année.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1004"/>
+        <location filename="../../song/QUSongFile.cpp" line="1011"/>
         <source>The audio file %1 does not contain ID3 tag information about a year.</source>
         <translation>Le fichier audio %1 ne contient pas d&apos;information concernant l&apos;année dans l&apos;ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1009"/>
+        <location filename="../../song/QUSongFile.cpp" line="1016"/>
         <source>ID3 tag of &quot;%1&quot; used for year. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>L&apos;ID3 de &quot;%1&quot;a été utilisé pour l&apos;année. Changement de : &quot;%2&quot; en &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1014"/>
+        <location filename="../../song/QUSongFile.cpp" line="1021"/>
         <source>The song &quot;%1 - %2&quot; has no unsupported tags.</source>
         <translation>La chanson &quot;%1 - %2&quot; n&apos;a pas de champs non supportés.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1022"/>
+        <location filename="../../song/QUSongFile.cpp" line="1029"/>
         <source>Unsupported tag removed: #%1.</source>
         <translation>Champ non supporté supprimé: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1024"/>
+        <location filename="../../song/QUSongFile.cpp" line="1031"/>
         <source>Unsupported tag skipped: #%1.</source>
         <translation>Champ non supporté sauté: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1045"/>
+        <location filename="../../song/QUSongFile.cpp" line="1052"/>
         <source>Assigned &quot;%1&quot; as audio file for &quot;%2 - %3&quot;.</source>
         <translation>&quot;%1&quot; assigné comme fichier audio pour &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1040"/>
+        <location filename="../../song/QUSongFile.cpp" line="1047"/>
         <source>Assigned &quot;%1&quot; as video file for &quot;%2 - %3&quot;.</source>
         <translation>&quot;%1&quot; assigné comme fichier vidéo pour &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="204"/>
+        <location filename="../../song/QUSongFile.cpp" line="198"/>
+        <source>Failed to detect line endings in file &quot;%1&quot;, defaulting to CRLF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../song/QUSongFile.cpp" line="214"/>
         <source>UTF8 detected in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="217"/>
+        <location filename="../../song/QUSongFile.cpp" line="227"/>
         <source>ENCODING:CP1252 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="222"/>
+        <location filename="../../song/QUSongFile.cpp" line="232"/>
         <source>ENCODING:CP1250 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="242"/>
+        <location filename="../../song/QUSongFile.cpp" line="252"/>
         <source>Not a valid UTF8 file and ENCODING tag missing. Defaulting to %1 in song file: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1053"/>
+        <location filename="../../song/QUSongFile.cpp" line="1060"/>
         <source>Assigned &quot;%1&quot; as cover picture for &quot;%2 - %3&quot;.</source>
         <translation>&quot;%1&quot; assigné comme fichier de couverture pour &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1056"/>
+        <location filename="../../song/QUSongFile.cpp" line="1063"/>
         <source>Assigned &quot;%1&quot; as background picture for &quot;%2 - %3&quot;.</source>
         <translation>&quot;%1&quot; assigné comme fichier de fond d&apos;écran pour &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1071"/>
+        <location filename="../../song/QUSongFile.cpp" line="1078"/>
         <source>Could not copy the file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Impossible de copier le fichier &quot;%1&quot; vers &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1075"/>
+        <location filename="../../song/QUSongFile.cpp" line="1082"/>
         <source>The file &quot;%1&quot; was successfully copied to &quot;%2&quot;.</source>
         <translation>Le fichier &quot;%1&quot; a été copié avec succès vers &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1107"/>
+        <location filename="../../song/QUSongFile.cpp" line="1114"/>
         <source>File removed successfully: &quot;%1&quot;.</source>
         <translation>Fichier supprimé avec succès: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1109"/>
+        <location filename="../../song/QUSongFile.cpp" line="1116"/>
         <source>File COULD NOT be removed: &quot;%1&quot;.</source>
         <translation>IMPOSSIBLE de supprimer le fichier: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1120"/>
+        <location filename="../../song/QUSongFile.cpp" line="1127"/>
         <source>Audio file tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Champ fichier audio supprimé pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1124"/>
+        <location filename="../../song/QUSongFile.cpp" line="1131"/>
         <source>Cover tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Champ couverture supprimé pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1128"/>
+        <location filename="../../song/QUSongFile.cpp" line="1135"/>
         <source>Background tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Champ fond d&apos;écran supprimé pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1133"/>
+        <location filename="../../song/QUSongFile.cpp" line="1140"/>
         <source>Video tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Champ fichier vidéo supprimé pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1147"/>
+        <location filename="../../song/QUSongFile.cpp" line="1154"/>
         <source>Old path and new path match! Cannot change song path to: &quot;%1&quot;</source>
         <translation>L&apos;Ancien et le nouveau dossier sont les mêmes! Impossible de changer le dossier en &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1152"/>
+        <location filename="../../song/QUSongFile.cpp" line="1159"/>
         <source>Could not create new song path: &quot;%1&quot;</source>
         <translation>Impossible de créer le nouveau dossier de la chanson: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1166"/>
+        <location filename="../../song/QUSongFile.cpp" line="1173"/>
         <source>Failed to move &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Echec du déplacement de &quot;%1&quot; vers &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1169"/>
+        <location filename="../../song/QUSongFile.cpp" line="1176"/>
         <source>The file &quot;%1&quot; was successfully moved to &quot;%2&quot;.</source>
         <translation>Le fichier &quot;%1&quot; a été déplacé avec succès vers &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1173"/>
+        <location filename="../../song/QUSongFile.cpp" line="1180"/>
         <source>Could NOT move all files of the song &quot;%2&quot; to a new location. Check out &quot;%1&quot; for the files which were copied.</source>
         <translation>IMPOSSIBLE de déplacer tous les fichiers de la chanson &quot;%2&quot; vers la nouvelle destination. Vérifiez dans &quot;%1&quot; les fichiers qui ont été copiés.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1183"/>
+        <location filename="../../song/QUSongFile.cpp" line="1190"/>
         <source>Could not remove old, empty folder &quot;%1&quot;. Please do it manually.</source>
         <translation>Impossible de supprimer l&apos;ancien dossier vide &quot;%1&quot;. Merci de la faire manuellement.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1190"/>
+        <location filename="../../song/QUSongFile.cpp" line="1197"/>
         <source>Location of song &quot;%1 - %2&quot; successfully changed to &quot;%3&quot; in your UltraStar song folder.</source>
         <translation>Emplacement de la chanson&quot;%1 - %2&quot; changé avec succès vers &quot;%3&quot; dans votre dossier de chanson UltraStar.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1201"/>
+        <location filename="../../song/QUSongFile.cpp" line="1208"/>
         <source>Could not fix audio length because no audio file is present: &quot;%1 - %2&quot;</source>
         <translation>Impossible de corriger la longueur du fichier audio car aucun fichier audio disponible pour: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1212"/>
+        <location filename="../../song/QUSongFile.cpp" line="1219"/>
         <source>Could not fix audio length because audio file is shorter than song: &quot;%1 - %2&quot;</source>
         <translation>Impossible de corriger la longueur du fichier audio car le fichier audio est plus court que la chanson pour: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1219"/>
+        <location filename="../../song/QUSongFile.cpp" line="1226"/>
         <source>Could not fix audio length because new value for #END would be greater than length of audio file: &quot;%1 - %2&quot;</source>
         <translation>Impossible de corriger la longueur du fichier audio car la nouvelle valeur de #END serait plus grande que la longueur du fichier audio pour: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1226"/>
+        <location filename="../../song/QUSongFile.cpp" line="1233"/>
         <source>Audio length was fixed for song &quot;%1 - %2&quot;. #END changed to: %3</source>
         <translation>La longueur de l&apos;audio a été corrigé pour la chanson &quot;%1 - %2&quot;. #END a été changé en : %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1241"/>
+        <location filename="../../song/QUSongFile.cpp" line="1248"/>
         <source>#GAP changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>#Gap a été changé de %1 en %2 pour &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1250"/>
+        <location filename="../../song/QUSongFile.cpp" line="1257"/>
         <source>The tag #END was removed for: &quot;%1 - %2&quot;</source>
         <translation>Le champ #END a été enlevé pour: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1262"/>
+        <location filename="../../song/QUSongFile.cpp" line="1269"/>
         <source>INCONSISTENT STATE! The song &quot;%1 - %2&quot; has unsaved changes and its persistent song file &quot;%3&quot; was modified externally. Save your changes or rebuild the tree manually.</source>
         <translation>ETAT INCOHERENT! La chanson &quot;%1 - %2&quot; a des changements non sauvegardés et son fichier &quot;%3&quot; a été modifié de façon externe. Sauvegardés vos changements ou actualisez l&apos;arborscence manuellement.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1268"/>
+        <location filename="../../song/QUSongFile.cpp" line="1275"/>
         <source>Song file changed: &quot;%1&quot;</source>
         <translation>Fichier de la chanson modifié: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1444"/>
+        <location filename="../../song/QUSongFile.cpp" line="1451"/>
         <source>Primary song file changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>La chanson principale a été changée de &quot;%1&quot; en &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1508"/>
+        <location filename="../../song/QUSongFile.cpp" line="1515"/>
         <source>Error while preparing lyrics for %1 - %2. Could not parse the following line: %3</source>
         <translation>Erreur lors de la préparation des paroles pour &quot;%1 - %2&quot;. Impossible de charger la ligne suivante: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1521"/>
+        <location filename="../../song/QUSongFile.cpp" line="1528"/>
         <source>Error while preparing lyrics for %1 - %2. Songs may not start with a line break.</source>
         <translation>Erreur lors de la préparation des paroles de %1 - %2. Les chansons ne peuvent pas commencer par un saut de ligne.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1545"/>
+        <location filename="../../song/QUSongFile.cpp" line="1552"/>
         <source>Line too short: &quot;%1&quot;</source>
         <translation>Ligne trop courte: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1601"/>
+        <location filename="../../song/QUSongFile.cpp" line="1608"/>
         <source>More than one score file found for &quot;%1 - %2&quot;. Only one will be used.</source>
         <translation>Plus d&apos;un fichier de score trouvé pour &quot;%1 - %2&quot;. Un seul sera utilisé.</translation>
     </message>
@@ -5980,7 +5985,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="144"/>
+        <source>Line Endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../songtree/QUSongTree.cpp" line="145"/>
+        <source>Shows whether the text file has CRLF or LF line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
         <source>Song</source>
         <translation>Chanson</translation>
     </message>
@@ -5989,12 +6004,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Longueur de la chanson calculée à partir du BPM et des paroles.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="150"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="152"/>
         <source>Indicates a problem with the difference of &lt;i&gt;song length&lt;/i&gt; and &lt;i&gt;audio length&lt;/i&gt;.&lt;br&gt;&lt;br&gt;The tooltip shows the difference.</source>
         <translation>Indique un problème avec la différence entre la &lt;i&gt;longueur de la chanson&lt;/i&gt; et &lt;i&gt;la longueur de la musique&lt;/i&gt;.&lt;br&gt;&lt;br&gt;L&apos;infobulle vous montre la différence.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="153"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
         <source>Audio</source>
         <translation>Musique</translation>
     </message>
@@ -6011,17 +6026,17 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Montrer la longueur réelle:&lt;br&gt;&lt;b&gt;longueur du fichier audio - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
         <source>Shows the number of singable syllables per second. No freestyle or pauses included.</source>
         <translation>Montrer le nombre de syllabes chantables par seconde. Freestyle et pause ne sont pas inclus.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
         <source>Start</source>
         <translation>Départ</translation>
     </message>
@@ -6030,7 +6045,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Sauter les premières secondes de la chanson.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="168"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
         <source>End</source>
         <translation>Fin</translation>
     </message>
@@ -6039,7 +6054,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Réinitialiser la longueur du fichier audio.&lt;br&gt;&lt;i&gt;(en millisecondes)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="171"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
         <source>Videogap</source>
         <translation>GAP de la Video</translation>
     </message>
@@ -6048,7 +6063,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Sauter les premières secondes de la vidéo.&lt;br&gt;&lt;br&gt;&lt;i&gt;Utiliser des valeurs négatives ici et des valeurs positives dans &lt;b&gt;#START&lt;/b&gt; pour régler un fichier video court.&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="169"/>
         <source>Shows how much time is skipped from the beginning of the audio file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Montre combien de temps est sauté à partir du début du fichier audio.&lt;br&gt;&lt;i&gt;(en secondes)&lt;/i&gt;</translation>
     </message>
@@ -6057,12 +6072,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Montre combien de temps est sauté à la fin du fichier audio.&lt;br&gt;&lt;i&gt;(en millisecondes)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
         <source>Shows how much time is skipped from the video file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Montre combien de temps est sauté dans le fichier vidéo.&lt;br&gt;&lt;i&gt;(en secondes)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
         <source>Relative?</source>
         <translation>Relatif?</translation>
     </message>
@@ -6071,7 +6086,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">A des marqueurs de temps relatifs.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
         <source>BPM</source>
         <translation>BPM</translation>
     </message>
@@ -6080,7 +6095,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Battements par minute</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
         <source>GAP</source>
         <translation>GAP</translation>
     </message>
@@ -6089,441 +6104,441 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Temps de la première syllabe.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="149"/>
         <source>Shows the song length calculated from BPM and lyrics.</source>
         <translation>Montre la longueur de la chanson calculée à partir du BPM et des paroles.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
         <source>Shows the length of audio file, if present.&lt;br&gt;&lt;br&gt;Can be reset through &lt;b&gt;#END&lt;/b&gt; tag.</source>
         <translation>Montre la longueur du fichier audio, si il est présent.&lt;br&gt;&lt;br&gt;Cela peut être changé grâce au champ &lt;b&gt;#END&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
         <source>Effective</source>
         <translation>Effectif</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
         <source>Shows the effective song length:&lt;br&gt;&lt;b&gt;audio length - #START&lt;/b&gt;.</source>
         <translation>Montrer la longueur réelle de la chanson:&lt;br&gt;&lt;b&gt;longueur du fichier audio - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="172"/>
         <source>Shows when the song playback stops.&lt;br&gt;&lt;i&gt;(in &lt;b&gt;milli&lt;/b&gt;seconds)&lt;/i&gt;</source>
         <translation>Montre quand la lecture de la chanson s&apos;arrète.&lt;br&gt;&lt;i&gt;(en &lt;b&gt;milli&lt;/b&gt;secondes)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="176"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="178"/>
         <source>Shows whether the song has relative timestamps.</source>
         <translation>Montre si votre chanson a des marqueurs de temps relatifs.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="181"/>
         <source>Shows the song tempo.&lt;br&gt;&lt;i&gt;(in beats per 15 seconds)</source>
         <translation>Montre le tempo de la chanson.&lt;br&gt;&lt;i&gt;(en nombre de beats par 15 secondes)</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="184"/>
         <source>Shows the gap between the beginning of the song and the first syllable.&lt;br&gt;&lt;i&gt;(in milliseconds)&lt;/i&gt;</source>
         <translation>Montre le gap entre le début de la chanson et la première syllabe.&lt;br&gt;&lt;i&gt;(en millisecondes)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="185"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="187"/>
         <source>Indicate duplicate songs. &lt;b&gt;You should not see me.&lt;/b&gt;</source>
         <translation>Indiquer les chansons en double. &lt;b&gt;Vous ne devriez pas les voir.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="323"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="325"/>
         <source>Saving unsaved changes...</source>
         <translation>Sauvegarde des changements non sauvegardées...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="394"/>
         <source>Filter removed. All songs are visible now.</source>
         <translation>Flitre enlevé. Toutes les chansons sont visibles maintenant.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="404"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="406"/>
         <source>Applying filter...</source>
         <translation>Application du filtre...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>Filter applied: &quot;%1&quot;%2</source>
         <translation>Filtre appliqué: &quot;%1&quot;%2</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>, negated</source>
         <translation>, inversé</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="517"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="519"/>
         <source>Looking for duplicate songs...</source>
         <translation>Recherche de chanson en double...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="568"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
         <source>Filter applied. Duplicates for %1 songs found.</source>
         <translation>Filtre appliqué. Doubles trouvés pour %1 chansons.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="572"/>
         <source>No duplicate songs found.</source>
         <translation>Pas de chanson en double trouvé.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="619"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
         <source>Hide</source>
         <translation>Masquer</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
         <source>Selected Songs</source>
         <translation>Chansons sélectionnées</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="624"/>
         <source>Selected Songs Only</source>
         <translation>Chansons sélectionnées seulement</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
         <source>Unselected Songs</source>
         <translation>Chansons non sélectionnées</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="637"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="627"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
         <source>All</source>
         <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="626"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="628"/>
         <source>None</source>
         <translation>Rien</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="636"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
         <source>Presets</source>
         <translation>Préréglages</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="640"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
         <source>Minimum</source>
         <translation>Minimum</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="643"/>
         <source>Spell &amp;&amp; File Checking</source>
         <translation>Vérification de l&apos;Orthographe &amp;&amp; du Fichier</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="642"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="644"/>
         <source>Time Comparison</source>
         <translation>Comparaison des temps</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="646"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
         <source>Custom Tags</source>
         <translation>Champs personnalisés</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="647"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="649"/>
         <source>Time &amp;&amp; Speed</source>
         <translation>Temps &amp;&amp; Vitesse</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="650"/>
         <source>Types</source>
         <translation>Types</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="856"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="860"/>
         <source>Hiding all visible songs...</source>
         <translation>Masquage de toutes les chansons visibles...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="879"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
         <source>Could not hide any item.</source>
         <translation>Impossible cacher les chansons.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="887"/>
         <source>Hiding selected songs...</source>
         <translation>Masquage des chansons sélectionnées...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="898"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="902"/>
         <source>%1 songs added to list of invisible songs.</source>
         <translation>%1 chansons ajoutées à la liste des chansons invisibles.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="923"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="927"/>
         <source>%1 songs are visible now.</source>
         <translation>%1 chansons sont visible maintenant.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="950"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="954"/>
         <source>All files in the song directory will be deleted including the directory itself if it is not empty.&lt;br&gt;&lt;br&gt;You want to delete the following &lt;b&gt;%1&lt;/b&gt; songs:</source>
         <translation>Tous les fichiers contenus dans le dossier des chansons seront supprimées, dossier inclus si il n&apos;est pas vide.&lt;br&gt;&lt;br&gt;Vous voulez supprimer les &lt;b&gt;%1&lt;/b&gt; chansons suivantes:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="963"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="967"/>
         <source>Delete Songs</source>
         <translation>Supprimer les chansons</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="965"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="969"/>
         <source>Delete these songs.</source>
         <translation>Supprimer ces chansons.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="966"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1430"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="970"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1434"/>
         <source>Cancel delete operation.</source>
         <translation>Annuler l&apos;opération de suppression.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="973"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="977"/>
         <source>Deleting selected songs...</source>
         <translation>Suppression des chansons sélectionnées...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1003"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1007"/>
         <source>Too few songs selected. You have to merge at least 2 songs.</source>
         <translation>Pas assez de chansons sélectionnées. Vous devez au minimum fusionner 2 chansons.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1016"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1020"/>
         <source>You want to merge songs with &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. All files of the other songs will be moved to that song&apos;s path.&lt;br&gt;&lt;br&gt;The following &lt;b&gt;%3&lt;/b&gt; songs will disappear:</source>
         <translation>Vous voulez fusionner les chansons avec &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. Tous les fichiers des autres chansons vont être transféré dans le dossier de cette chanson.&lt;br&gt;&lt;br&gt;Les &lt;b&gt;%3&lt;/b&gt; chansons suivantes vont disparaitre:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1029"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1033"/>
         <source>Merge Songs</source>
         <translation>Fusionner les chansons</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1031"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1035"/>
         <source>Merge these songs.</source>
         <translation>Fusionner ces chansons.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1032"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1036"/>
         <source>Cancel merge operation.</source>
         <translation>Annuler l&apos;opération de fusion.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1039"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1043"/>
         <source>Merging selected songs with &quot;%1 - %2&quot;...</source>
         <translation>Fusion des chansons sélectionnées avec &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1060"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1064"/>
         <source>Could NOT copy file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>IMPOSSIBLE de copier le fichier &quot;%1&quot; vers&quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1062"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1066"/>
         <source>File was copied successfully from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Fichier copié avec succès de &quot;%1&quot; vers &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1071"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1075"/>
         <source>Not all files of &quot;%1 - %2&quot; were copied. Song will not be deleted. Merging failed.</source>
         <translation>Tous les fichiers de &quot;%1 - %2&quot; n&apos;ont pu être copiés. La chanson ne sera pas supprimée. La fusion a échouée.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1085"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1089"/>
         <source>Calculate selected song speeds...</source>
         <translation>Calcul de la vitesse des chansons sélectionnées...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1106"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1110"/>
         <source>Calculating selected song ReplayGain...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1121"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1125"/>
         <source>Copy Files</source>
         <translation>Copie des fichiers</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1122"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1126"/>
         <source>You want to copy &lt;b&gt;%1&lt;/b&gt; files to &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</source>
         <translation>Vous souhaitez copier &lt;b&gt;%1&lt;/b&gt; fichiers vers &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1123"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1127"/>
         <source>Copy these files.</source>
         <translation>Copier ces fichiers.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1124"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1128"/>
         <source>Cancel copy operation.</source>
         <translation>Annuler l&apos;opération de copie.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1131"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1135"/>
         <source>Copy &amp; Use files for the song: &quot;%1 - %2&quot;...</source>
         <translation>Copier et Utiliser les fichiers pour la chanson: &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1165"/>
         <source>Including new songs to database...</source>
         <translation>Ajout de nouvelles chansons à la base de donnée...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1179"/>
         <source>Invalid song file found: &quot;%1&quot;. Cannot include those.</source>
         <translation>Chanson invalide trouvée: &quot;%1&quot;. Impossible de l&apos;inclure.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1184"/>
         <source>Cannot include license files as songs: &quot;%1&quot;</source>
         <translation>Impossible d&apos;inclure un fichier de licence en tant que chanson: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1191"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1195"/>
         <source>Could not copy song file &quot;%1&quot; to new song directory &quot;%2&quot;!</source>
         <translation>Impossible de copier le fichier de la chanson &quot;%1&quot; vers le nouveau dossier de la chanson &quot;%2&quot;!</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1199"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1203"/>
         <source>New song included to your song collection: &quot;%1 - %2&quot;.</source>
         <translation>Nouvelle chanson incluse dans votre collection de chanson: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1238"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1242"/>
         <source>Could not create directory: &quot;%1&quot;. Disk full?</source>
         <translation>Impossible de crééer le dossier: &quot;%1&quot;. Disque plein?</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1258"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1262"/>
         <source>Refreshing selected songs...</source>
         <translation>Actualisation des chansons sélectionnées...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1303"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1307"/>
         <source>Saving selected songs...</source>
         <translation>Sauvegarde des chansons sélectionnées...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1336"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1340"/>
         <source>Show preview</source>
         <translation>Afficher une prévisualisation</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1337"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
         <source>Open image file externally</source>
         <translation>Ouvrir le fichier image de façon externe</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1339"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
         <source>Open video file externally</source>
         <translation>Ouvrir le fichier video de façon externe</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1345"/>
         <source>Open audio file externally</source>
         <translation>Ouvrir le fichier audio de façon externe</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1347"/>
         <source>Show file contents</source>
         <translation>Afficher le contenu du fichier</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1344"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1348"/>
         <source>Open text file externally</source>
         <translation>Ouvrir le fichier texte de façon externe</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1346"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1350"/>
         <source>Set as primary song</source>
         <translation>Régler en tant que chanson principale</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1349"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1353"/>
         <source>Open externally</source>
         <translation>Ouvrir de façon externe</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1372"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
         <source>Calculate Song ReplayGain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1379"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1383"/>
         <source>Open With Finder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1382"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
         <source>Open With File Manager...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
         <source>Search for cover on AlbumArtExchange...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
         <source>Search for cover on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1391"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
         <source>Search for artwork on Fanart...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
         <source>Search for background on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1397"/>
         <source>Search for video on Google Video...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1398"/>
         <source>Search for video on Youtube...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1399"/>
         <source>Look up on Hitparade.ch...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
         <source>Look up on USDB...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1404"/>
         <source>Create Duet From Song Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1570"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1595"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1618"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1641"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1664"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1686"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1706"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1728"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1574"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1599"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1645"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1668"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1690"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1710"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1732"/>
         <source>You can only look up one song at a time.</source>
         <translation>Vous ne pouvez regarder qu&apos;une seule chanson à la fois.</translation>
     </message>
@@ -6532,78 +6547,78 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Ouvrir</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1351"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1356"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1360"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1354"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1358"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1357"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1361"/>
         <source>Merge</source>
         <translation>Fusionner</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
         <source>Play</source>
         <translation>Lecture</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1362"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
         <source>Send To Playlist</source>
         <translation>Ajouter à la liste de lecture</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
         <source>Get Covers...</source>
         <translation>Obtention des couvertures...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1365"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1369"/>
         <source>Review pictures</source>
         <translation>Prévisualiser les images</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1370"/>
         <source>Covers...</source>
         <translation>Couvertures...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
         <source>Backgrounds...</source>
         <translation>Fond d&apos;écran...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1375"/>
         <source>Calculate Song Speed</source>
         <translation>Calcul de la vitesse de la chanson</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1380"/>
         <source>Open With Explorer...</source>
         <translation>Ouvrir avec l&apos;explorateur de fichier...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1384"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1388"/>
         <source>Find More From Artist</source>
         <translation>Trouver plus de chansons du même artiste</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1385"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
         <source>Show Lyrics...</source>
         <translation>Afficher les paroles...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
         <source>Edit Lyrics...</source>
         <translation>Editer les paroles...</translation>
     </message>
@@ -6612,42 +6627,42 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Recherche sur Hitparade...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1427"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1431"/>
         <source>Delete File</source>
         <translation>Supprimer le fichier</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1428"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1432"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; will be deleted permanently. You cannot undo a delete operation.</source>
         <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; va être supprimé de façon permanente. Vous ne pouvez pas annuler une opération de suppression.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1429"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1433"/>
         <source>Delete this file.</source>
         <translation>Supprimer ce fichier.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1435"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1439"/>
         <source>The file &quot;%1&quot; was deleted successfully.</source>
         <translation>Le fichier &quot;%1&quot; a été supprimé avec succès.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1437"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1441"/>
         <source>The file &quot;%1&quot; was NOT deleted.</source>
         <translation>Le fichier &quot;%1&quot; n&apos;a PAS été supprimé.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1474"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1478"/>
         <source>You can only display the lyrics of one song at a time.</source>
         <translation>Vous ne pouvez afficher les paroles que d&apos;une seule chanson à la fois.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1484"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1488"/>
         <source>You can only edit the lyrics of one song at a time.</source>
         <translation>Vous ne pouvez éditer les paroles que d&apos;une seule chanson à la fois.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1506"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1510"/>
         <source>Removing current filter...</source>
         <translation>Suppression des filtres actuels...</translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.pl.ts
+++ b/src/resources/lang/UltraStar-Manager.pl.ts
@@ -5697,356 +5697,361 @@ p, li { white-space: pre-wrap; }
         <translation>Nie mogę odczytać pliku utworu: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="228"/>
+        <location filename="../../song/QUSongFile.cpp" line="238"/>
         <source>Encoding mismatch. Defaulting to %1 for song file: &quot;%2&quot;</source>
         <translation>Kodowanie niedopasowane. Domyślnie: %1 dla piosenki: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="233"/>
+        <location filename="../../song/QUSongFile.cpp" line="243"/>
         <source>&quot;%1&quot; unsupported. Defaulting to %2 for song file: &quot;%3&quot;</source>
         <translation>&quot;%1&quot; nieobsługiwane. Domyślnie %2 dla piosenki: &quot;%3&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="357"/>
+        <location filename="../../song/QUSongFile.cpp" line="367"/>
         <source>Deprecated tag information detected.</source>
         <translation>Wykryte przestarzałe etykiety.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="358"/>
+        <location filename="../../song/QUSongFile.cpp" line="368"/>
         <source>The number of available tags in your configuration and that one this application offers are different.</source>
         <translation>Liczba dostępnych etykiet w konfiguracji z tą którą oferuje aplikacja jest inna.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="359"/>
+        <location filename="../../song/QUSongFile.cpp" line="369"/>
         <source>The tag order was reset to its default order. Check out the options to set up your custom order again.</source>
         <translation>Tag został zresetowany do domyślnej kolejności. Zapoznaj się z opcjami, aby skonfigurować niestandardowe żądanie ponownie.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="709"/>
+        <location filename="../../song/QUSongFile.cpp" line="719"/>
         <source>Save error! The song file &quot;%1&quot; was NOT saved.</source>
         <translation>Błąd zapisu! Plik utworu &quot;%1&quot; nie został zachowany.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="768"/>
+        <location filename="../../song/QUSongFile.cpp" line="775"/>
         <source>The song file &quot;%1&quot; was saved successfully.</source>
         <translation>Plik utworu &quot;%1&quot; został zachowany.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="785"/>
+        <location filename="../../song/QUSongFile.cpp" line="792"/>
         <source>Old name and new name match: &quot;%1&quot;</source>
         <translation>Stara i nowa nazwa są zgodne z: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="810"/>
+        <location filename="../../song/QUSongFile.cpp" line="817"/>
         <source>Could NOT rename the song directory &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę zmienić nazwy katalogu z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="818"/>
+        <location filename="../../song/QUSongFile.cpp" line="825"/>
         <source>Song directory renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Nazwa katalogu zmieniona z &quot;%1&quot; na: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="829"/>
+        <location filename="../../song/QUSongFile.cpp" line="836"/>
         <source>Could NOT rename the song file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę zmienić nazwy pliku utworu z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="836"/>
+        <location filename="../../song/QUSongFile.cpp" line="843"/>
         <source>Song file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Nazwa pliku utworu zmieniona z &quot;%1&quot; na: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="848"/>
+        <location filename="../../song/QUSongFile.cpp" line="855"/>
         <source>Could NOT rename the audio file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę zmienić nazwy pliku z muzyką z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="853"/>
-        <location filename="../../song/QUSongFile.cpp" line="923"/>
+        <location filename="../../song/QUSongFile.cpp" line="860"/>
+        <location filename="../../song/QUSongFile.cpp" line="930"/>
         <source>Audio file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Nazwa pliku z muzyką zmieniona  z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="870"/>
+        <location filename="../../song/QUSongFile.cpp" line="877"/>
         <source>Could NOT rename the cover picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę zmienić nazwy pliku okładki z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="875"/>
-        <location filename="../../song/QUSongFile.cpp" line="901"/>
+        <location filename="../../song/QUSongFile.cpp" line="882"/>
+        <location filename="../../song/QUSongFile.cpp" line="908"/>
         <source>Cover picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Nazwa pliku okładki zmieniona z &quot;%1&quot; na: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="892"/>
+        <location filename="../../song/QUSongFile.cpp" line="899"/>
         <source>Could NOT rename the background picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę zmenić nazwy pliku tła z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="879"/>
-        <location filename="../../song/QUSongFile.cpp" line="897"/>
+        <location filename="../../song/QUSongFile.cpp" line="886"/>
+        <location filename="../../song/QUSongFile.cpp" line="904"/>
         <source>Background picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Nazwa pliku tła zmieniona z &quot;%1&quot; na: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="914"/>
+        <location filename="../../song/QUSongFile.cpp" line="921"/>
         <source>Could NOT rename the video file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę zmienić nazwy pliku teledysku z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="857"/>
-        <location filename="../../song/QUSongFile.cpp" line="919"/>
+        <location filename="../../song/QUSongFile.cpp" line="864"/>
+        <location filename="../../song/QUSongFile.cpp" line="926"/>
         <source>Video file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Nazwa pliku teledysku zmieniona z &quot;%1&quot; na: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="933"/>
+        <location filename="../../song/QUSongFile.cpp" line="940"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for artist.</source>
         <translation>Utwór &quot;%1 - %2&quot; nie ma przypisanego pliku z muzyką. Nie mogę użyć informacji o wykonawcy z etykiety ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="944"/>
+        <location filename="../../song/QUSongFile.cpp" line="951"/>
         <source>The audio file %1 does not contain ID3 tag information about an artist.</source>
         <translation>Plik z muzyką %1 nie zawiera informacji na temat wykonawcy w etykiecie ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="949"/>
+        <location filename="../../song/QUSongFile.cpp" line="956"/>
         <source>ID3 tag of &quot;%1&quot; used for artist. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Informacja z etykiety ID3 &quot;%1&quot; została użyta do zmiany wykonawcy z: &quot;%2&quot; na &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="954"/>
+        <location filename="../../song/QUSongFile.cpp" line="961"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for title.</source>
         <translation>Utwór &quot;%1 - %2&quot; nie ma przypisanego pliku z muzyką. Nie mogę użyć informacji o tytule z etykiety ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="964"/>
+        <location filename="../../song/QUSongFile.cpp" line="971"/>
         <source>The audio file %1 does not contain ID3 tag information about a title.</source>
         <translation>Plik z muzyką %1 nie zawiera informacji na temat tytułu w etykiecie ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="969"/>
+        <location filename="../../song/QUSongFile.cpp" line="976"/>
         <source>ID3 tag of &quot;%1&quot; used for title. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Informacja z etykiety ID3 &quot;%1&quot; została użyta do zmiany tytułu z: &quot;%2&quot; na &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="974"/>
+        <location filename="../../song/QUSongFile.cpp" line="981"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for genre.</source>
         <translation>Utwór &quot;%1 - %2&quot; nie ma przypisanego pliku z muzyką. Nie mogę użyć informacji o rodzaju muzyki z etykiety ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="984"/>
+        <location filename="../../song/QUSongFile.cpp" line="991"/>
         <source>The audio file %1 does not contain ID3 tag information about a genre.</source>
         <translation>Plik z muzyką %1 nie zawiera informacji na temat rodzaju muzyki w etykiecie ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="989"/>
+        <location filename="../../song/QUSongFile.cpp" line="996"/>
         <source>ID3 tag of &quot;%1&quot; used for genre. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Informacja z etykiety ID3 &quot;%1&quot; została użyta do zmiany rodzaj muzyki z: &quot;%2&quot; na &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="994"/>
+        <location filename="../../song/QUSongFile.cpp" line="1001"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for year.</source>
         <translation>Utwór &quot;%1 - %2&quot; nie ma przypisanego pliku z muzyką. Nie mogę użyć informacji o roku powstania utworu z etykiety ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1004"/>
+        <location filename="../../song/QUSongFile.cpp" line="1011"/>
         <source>The audio file %1 does not contain ID3 tag information about a year.</source>
         <translation>Plik z muzyką %1 nie zawiera informacji na temat roku powstania utworu w etykiecie ID3.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1009"/>
+        <location filename="../../song/QUSongFile.cpp" line="1016"/>
         <source>ID3 tag of &quot;%1&quot; used for year. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Informacja z etykiety ID3 &quot;%1&quot; została użyta do zmiany roku powstania utworu z: &quot;%2&quot; na &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1014"/>
+        <location filename="../../song/QUSongFile.cpp" line="1021"/>
         <source>The song &quot;%1 - %2&quot; has no unsupported tags.</source>
         <translation>Utwór &quot;%1 - %2&quot; ma etykiety, których nie rozpoznaje ten program.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1022"/>
+        <location filename="../../song/QUSongFile.cpp" line="1029"/>
         <source>Unsupported tag removed: #%1.</source>
         <translation>Nierozpoznane etykiety zostały usunięte: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1024"/>
+        <location filename="../../song/QUSongFile.cpp" line="1031"/>
         <source>Unsupported tag skipped: #%1.</source>
         <translation>Nieobsługiwany tag ominięty: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1045"/>
+        <location filename="../../song/QUSongFile.cpp" line="1052"/>
         <source>Assigned &quot;%1&quot; as audio file for &quot;%2 - %3&quot;.</source>
         <translation>Przypisano &quot;%1&quot; jako plik audio do &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1040"/>
+        <location filename="../../song/QUSongFile.cpp" line="1047"/>
         <source>Assigned &quot;%1&quot; as video file for &quot;%2 - %3&quot;.</source>
         <translation>Przypisano &quot;%1&quot; jako teledysk dla &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="204"/>
+        <location filename="../../song/QUSongFile.cpp" line="198"/>
+        <source>Failed to detect line endings in file &quot;%1&quot;, defaulting to CRLF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../song/QUSongFile.cpp" line="214"/>
         <source>UTF8 detected in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="217"/>
+        <location filename="../../song/QUSongFile.cpp" line="227"/>
         <source>ENCODING:CP1252 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="222"/>
+        <location filename="../../song/QUSongFile.cpp" line="232"/>
         <source>ENCODING:CP1250 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="242"/>
+        <location filename="../../song/QUSongFile.cpp" line="252"/>
         <source>Not a valid UTF8 file and ENCODING tag missing. Defaulting to %1 in song file: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1053"/>
+        <location filename="../../song/QUSongFile.cpp" line="1060"/>
         <source>Assigned &quot;%1&quot; as cover picture for &quot;%2 - %3&quot;.</source>
         <translation>Przypisano &quot;%1&quot; jako okładkę dla &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1056"/>
+        <location filename="../../song/QUSongFile.cpp" line="1063"/>
         <source>Assigned &quot;%1&quot; as background picture for &quot;%2 - %3&quot;.</source>
         <translation>Przypisano &quot;%1&quot; jako tło dla &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1071"/>
+        <location filename="../../song/QUSongFile.cpp" line="1078"/>
         <source>Could not copy the file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę skopiować pliku &quot;%1&quot; do &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1075"/>
+        <location filename="../../song/QUSongFile.cpp" line="1082"/>
         <source>The file &quot;%1&quot; was successfully copied to &quot;%2&quot;.</source>
         <translation>Plik &quot;%1&quot; został skopiowany do &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1107"/>
+        <location filename="../../song/QUSongFile.cpp" line="1114"/>
         <source>File removed successfully: &quot;%1&quot;.</source>
         <translation>Plik &quot;%1&quot; został usunięty.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1109"/>
+        <location filename="../../song/QUSongFile.cpp" line="1116"/>
         <source>File COULD NOT be removed: &quot;%1&quot;.</source>
         <translation>Plik nie może być usunięty: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1120"/>
+        <location filename="../../song/QUSongFile.cpp" line="1127"/>
         <source>Audio file tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etykieta pliku Audio została usunięta. Dotyczy &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1124"/>
+        <location filename="../../song/QUSongFile.cpp" line="1131"/>
         <source>Cover tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etykieta Okładki została usunięta. Dotyczy &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1128"/>
+        <location filename="../../song/QUSongFile.cpp" line="1135"/>
         <source>Background tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etykieta Tła została usunięta. Dotyczy &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1133"/>
+        <location filename="../../song/QUSongFile.cpp" line="1140"/>
         <source>Video tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etykieta Teledysku została usunięta. Dotyczy &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1147"/>
+        <location filename="../../song/QUSongFile.cpp" line="1154"/>
         <source>Old path and new path match! Cannot change song path to: &quot;%1&quot;</source>
         <translation>Stara i nowa ścieżka są identyczne! Nie mogę zmienić ścieżki utworu na: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1152"/>
+        <location filename="../../song/QUSongFile.cpp" line="1159"/>
         <source>Could not create new song path: &quot;%1&quot;</source>
         <translation>Nie mogę utworzyć nowej ścieżki utworu: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1166"/>
+        <location filename="../../song/QUSongFile.cpp" line="1173"/>
         <source>Failed to move &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie udało się przenieść &quot;%1&quot; do &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1169"/>
+        <location filename="../../song/QUSongFile.cpp" line="1176"/>
         <source>The file &quot;%1&quot; was successfully moved to &quot;%2&quot;.</source>
         <translation>Plik &quot;%1&quot; został przeniesiony do &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1173"/>
+        <location filename="../../song/QUSongFile.cpp" line="1180"/>
         <source>Could NOT move all files of the song &quot;%2&quot; to a new location. Check out &quot;%1&quot; for the files which were copied.</source>
         <translation>NIE mogę przenieść wszystkich plików utworu &quot;%2&quot; w nowe miejse. Sprawdź &quot;%1&quot; które z plików zostały skopiowane.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1183"/>
+        <location filename="../../song/QUSongFile.cpp" line="1190"/>
         <source>Could not remove old, empty folder &quot;%1&quot;. Please do it manually.</source>
         <translation>Nie mogę usunąć starego, pustego katalogu &quot;%1&quot;. Spróbuj zrobić to ręcznie, lub po ponownym uruchomieniu systemu.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1190"/>
+        <location filename="../../song/QUSongFile.cpp" line="1197"/>
         <source>Location of song &quot;%1 - %2&quot; successfully changed to &quot;%3&quot; in your UltraStar song folder.</source>
         <translation>Położenie utworu &quot;%1 - %2&quot; zostało zmienione na &quot;%3&quot; w Twoim katalogu utworów UltraStar&apos;a.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1201"/>
+        <location filename="../../song/QUSongFile.cpp" line="1208"/>
         <source>Could not fix audio length because no audio file is present: &quot;%1 - %2&quot;</source>
         <translation>Nie mogę poprawić długości muzyki, ponieważ plik z muzyką nie został znaleziony: &quot;%1 -%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1212"/>
+        <location filename="../../song/QUSongFile.cpp" line="1219"/>
         <source>Could not fix audio length because audio file is shorter than song: &quot;%1 - %2&quot;</source>
         <translation>Nie mogę poprawić długości muzyki, ponieważ plik z muzyką jest krótszy od długości utworu w TXT: &quot;%1 -%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1219"/>
+        <location filename="../../song/QUSongFile.cpp" line="1226"/>
         <source>Could not fix audio length because new value for #END would be greater than length of audio file: &quot;%1 - %2&quot;</source>
         <translation>Nie mogę poprawić długości muzyki, ponieważ wartość etykiety #END jest wyższa i wykracza poza długość pliku z muzyką: &quot;%1 -%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1226"/>
+        <location filename="../../song/QUSongFile.cpp" line="1233"/>
         <source>Audio length was fixed for song &quot;%1 - %2&quot;. #END changed to: %3</source>
         <translation>Długość Muzyki została poprawiona. Utwór &quot;%1 - %2&quot; ma etykietę #END ustawioiną na: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1250"/>
+        <location filename="../../song/QUSongFile.cpp" line="1257"/>
         <source>The tag #END was removed for: &quot;%1 - %2&quot;</source>
         <translation>Etykieta #END została usunięta z: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1262"/>
+        <location filename="../../song/QUSongFile.cpp" line="1269"/>
         <source>INCONSISTENT STATE! The song &quot;%1 - %2&quot; has unsaved changes and its persistent song file &quot;%3&quot; was modified externally. Save your changes or rebuild the tree manually.</source>
         <translation>Niespójny stan! Piosenka &quot;%1 - %2&quot; miała niezapisane zmiany i plik &quot;%3&quot; został zmieniony poza programem. Zapisz zmiany.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1268"/>
+        <location filename="../../song/QUSongFile.cpp" line="1275"/>
         <source>Song file changed: &quot;%1&quot;</source>
         <translation>Plik piosenki zmieniony: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1444"/>
+        <location filename="../../song/QUSongFile.cpp" line="1451"/>
         <source>Primary song file changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Podstawowy plik piosenki zmieniony z &quot;%1&quot; na &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1508"/>
+        <location filename="../../song/QUSongFile.cpp" line="1515"/>
         <source>Error while preparing lyrics for %1 - %2. Could not parse the following line: %3</source>
         <translation>Błąd podczas przygotowywania teksty piosenki dla %1 - %2. Nie można przetworzyć następującej linijki: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1521"/>
+        <location filename="../../song/QUSongFile.cpp" line="1528"/>
         <source>Error while preparing lyrics for %1 - %2. Songs may not start with a line break.</source>
         <translation>Błąd podczas przygotowywania tekstu piosenki dla %1 - %2. Utwory nie mogą zaczynać się od końca linii.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1601"/>
+        <location filename="../../song/QUSongFile.cpp" line="1608"/>
         <source>More than one score file found for &quot;%1 - %2&quot;. Only one will be used.</source>
         <translation>Więcej niż jeden wynik dla pliku %1 - %2&quot;. Tylko jeden będzie użyty.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1241"/>
+        <location filename="../../song/QUSongFile.cpp" line="1248"/>
         <source>#GAP changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>#GAP w &quot;%3 - %4&quot; został zmieniony z %1 na %2.</translation>
     </message>
@@ -6055,7 +6060,7 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">%1 kodowanie wyjściowe jest NIE wystarczające. Użyj UTF8 dla pliku piosenki: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1545"/>
+        <location filename="../../song/QUSongFile.cpp" line="1552"/>
         <source>Line too short: &quot;%1&quot;</source>
         <translation>Za krótka linia: &quot;%1&quot;</translation>
     </message>
@@ -6267,7 +6272,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="144"/>
+        <source>Line Endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../songtree/QUSongTree.cpp" line="145"/>
+        <source>Shows whether the text file has CRLF or LF line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
         <source>Song</source>
         <translation>Utwór</translation>
     </message>
@@ -6276,12 +6291,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Długość utworu obliczona na podstawie BPM i tekstu piosenki.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="150"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="152"/>
         <source>Indicates a problem with the difference of &lt;i&gt;song length&lt;/i&gt; and &lt;i&gt;audio length&lt;/i&gt;.&lt;br&gt;&lt;br&gt;The tooltip shows the difference.</source>
         <translation>Zwraca uwagę na różnicę pomiędzy &lt;i&gt;długością utworu (TXT)&lt;/i&gt; a &lt;i&gt;długością piosenki (Muzyka)&lt;/i&gt;.&lt;br&gt;&lt;br&gt;Po najechaniu myszką wyświetlona zostanie wielkość tej różnicy.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="153"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
         <source>Audio</source>
         <translation>Muzyka</translation>
     </message>
@@ -6298,7 +6313,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Pokazuje długość rzeczywistą&quot;&lt;br&gt;&lt;b&gt;długość muzyki - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
         <source>Start</source>
         <translation>Początek</translation>
     </message>
@@ -6307,7 +6322,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Pomiń początkowe sekundy utworu.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="168"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
         <source>End</source>
         <translation>Koniec</translation>
     </message>
@@ -6316,7 +6331,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Przywraca domyślną długość pliku audio.&lt;br&gt;&lt;i&gt;(w milisekundach)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="171"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
         <source>Videogap</source>
         <translation>Przesunięcie Video</translation>
     </message>
@@ -6325,7 +6340,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Pomija pierwsze sekundy teledysku.&lt;br&gt;&lt;br&gt;&lt;i&gt;Użyj ujemnych wartości tutaj, oraz dodatnich w etykiecie &lt;b&gt;#START&lt;/b&gt; by dopasować zbyt krótki plik teledysku.&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
         <source>Relative?</source>
         <translation>Względny?</translation>
     </message>
@@ -6334,7 +6349,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Has relative timestamps.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
         <source>BPM</source>
         <translation>BPM</translation>
     </message>
@@ -6343,7 +6358,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">uderzeń na minutę</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
         <source>GAP</source>
         <translation>GAP</translation>
     </message>
@@ -6352,97 +6367,97 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Czas do pierwszej sylaby.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="185"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="187"/>
         <source>Indicate duplicate songs. &lt;b&gt;You should not see me.&lt;/b&gt;</source>
         <translation>Pokazuje zduplikowane utwory. &lt;b&gt;Nie powinieneś mnie widzieć.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="323"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="325"/>
         <source>Saving unsaved changes...</source>
         <translation>Zapis niezachowanych  zmian...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="394"/>
         <source>Filter removed. All songs are visible now.</source>
         <translation>Filtr usunięty. Wszystkie utwory są teraz widoczne.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="404"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="406"/>
         <source>Applying filter...</source>
         <translation>Stosowanie filtrowania...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>Filter applied: &quot;%1&quot;%2</source>
         <translation>Filtr zastosowany: &quot;%1&quot;%2</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>, negated</source>
         <translation>, odrzucony</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="517"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="519"/>
         <source>Looking for duplicate songs...</source>
         <translation>Szukanie zduplikowanych utworów...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="568"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
         <source>Filter applied. Duplicates for %1 songs found.</source>
         <translation>Filtr zastosowany. Znaleziona ilość duplikatów utworów %1.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="572"/>
         <source>No duplicate songs found.</source>
         <translation>Nie znaleziono zduplikowanych utworów.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="626"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="628"/>
         <source>None</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="898"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="902"/>
         <source>%1 songs added to list of invisible songs.</source>
         <translation>%1 piosenek dodanych do listy ukrytych.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1258"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1262"/>
         <source>Refreshing selected songs...</source>
         <translation>Odświeżanie wybranych piosenek...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1336"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1340"/>
         <source>Show preview</source>
         <translation>Pokaż podgląd</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1337"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
         <source>Open image file externally</source>
         <translation>Otwórz obrazek poza programem</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1339"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
         <source>Open video file externally</source>
         <translation>Otwórz teledysk poza programem</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1345"/>
         <source>Open audio file externally</source>
         <translation>Otwórz plik audio poza programem</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1347"/>
         <source>Show file contents</source>
         <translation>Pokaż zawartość pliku</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1344"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1348"/>
         <source>Open text file externally</source>
         <translation>Otwórz plik tekstowy poza programem</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1346"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1350"/>
         <source>Set as primary song</source>
         <translation>Ustaw jako podstawą piosenkę</translation>
     </message>
@@ -6451,28 +6466,28 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Otwórz</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1351"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1356"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1360"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1357"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1361"/>
         <source>Merge</source>
         <translation>Połącz</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
         <source>Play</source>
         <translation>Odtwarzaj</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1362"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
         <source>Send To Playlist</source>
         <translation>Wyślij do Listy Odtwarzania</translation>
     </message>
@@ -6481,148 +6496,148 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Pobierz Okładki z Amazon...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1365"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1369"/>
         <source>Review pictures</source>
         <translation>Przeglądaj obrazki</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1370"/>
         <source>Covers...</source>
         <translation>Okładki...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
         <source>Backgrounds...</source>
         <translation>Tła...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="619"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
         <source>Hide</source>
         <translation>Ukryj</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="149"/>
         <source>Shows the song length calculated from BPM and lyrics.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
         <source>Shows the length of audio file, if present.&lt;br&gt;&lt;br&gt;Can be reset through &lt;b&gt;#END&lt;/b&gt; tag.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
         <source>Effective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
         <source>Shows the effective song length:&lt;br&gt;&lt;b&gt;audio length - #START&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="172"/>
         <source>Shows when the song playback stops.&lt;br&gt;&lt;i&gt;(in &lt;b&gt;milli&lt;/b&gt;seconds)&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="176"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="178"/>
         <source>Shows whether the song has relative timestamps.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="181"/>
         <source>Shows the song tempo.&lt;br&gt;&lt;i&gt;(in beats per 15 seconds)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
         <source>Selected Songs</source>
         <translation>Wybrane Utwory</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="624"/>
         <source>Selected Songs Only</source>
         <translation>Tylko Wybrane Utwory</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
         <source>Unselected Songs</source>
         <translation>Niewybrane Utwory</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="637"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="627"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
         <source>All</source>
         <translation>Wszystko</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1385"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
         <source>Show Lyrics...</source>
         <translation>Pokaż Teksty Piosenek...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
         <source>Edit Lyrics...</source>
         <translation>Edytuj słowa piosenki...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="636"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
         <source>Presets</source>
         <translation>Zdefiniowane Widoki</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="169"/>
         <source>Shows how much time is skipped from the beginning of the audio file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
         <source>Shows how much time is skipped from the video file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="184"/>
         <source>Shows the gap between the beginning of the song and the first syllable.&lt;br&gt;&lt;i&gt;(in milliseconds)&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="640"/>
         <source>Default</source>
         <translation>Domyślny</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
         <source>Minimum</source>
         <translation>Minimalny</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="643"/>
         <source>Spell &amp;&amp; File Checking</source>
         <translation>Sprawdzanie Słownictwa i Plików</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="642"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="644"/>
         <source>Time Comparison</source>
         <translation>Porównanie Czasu</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="646"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
         <source>Custom Tags</source>
         <translation>Własne Etykiety</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="856"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="860"/>
         <source>Hiding all visible songs...</source>
         <translation>Ukrywanie wszystkich widocznych utworów...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="879"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
         <source>Could not hide any item.</source>
         <translation>Nie możesz ukryć żadnego elementu.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="887"/>
         <source>Hiding selected songs...</source>
         <translation>Ukrywanie wybranych utworów...</translation>
     </message>
@@ -6631,310 +6646,310 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">%1 utworów zostało dodanych do listy ukrytych utworów.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="923"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="927"/>
         <source>%1 songs are visible now.</source>
         <translation>%1 utworów jest teraz widoczne.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="950"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="954"/>
         <source>All files in the song directory will be deleted including the directory itself if it is not empty.&lt;br&gt;&lt;br&gt;You want to delete the following &lt;b&gt;%1&lt;/b&gt; songs:</source>
         <translation>Wszystkie pliki w katalogu utworu zostaną usunięte wraz całym katalogiem.&lt;br&gt;&lt;br&gt;Chcesz usunąć &lt;b&gt;%1&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="963"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="967"/>
         <source>Delete Songs</source>
         <translation>Usuń Utwory</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="965"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="969"/>
         <source>Delete these songs.</source>
         <translation>Usuń te utwory.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="966"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1430"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="970"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1434"/>
         <source>Cancel delete operation.</source>
         <translation>Anuluj usuwanie.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="973"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="977"/>
         <source>Deleting selected songs...</source>
         <translation>Usuwam wybrane utwory...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1003"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1007"/>
         <source>Too few songs selected. You have to merge at least 2 songs.</source>
         <translation>Wybrano za mało utworów.Ilość utworów jakie można połączyć zaczyna się od dwóch.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1016"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1020"/>
         <source>You want to merge songs with &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. All files of the other songs will be moved to that song&apos;s path.&lt;br&gt;&lt;br&gt;The following &lt;b&gt;%3&lt;/b&gt; songs will disappear:</source>
         <translation>Zamierzasz połączyć &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. Wszystkie pliki innych piosenek zostaną przeniesione do tego katalogu.&lt;br&gt;&lt;br&gt;Znikną następujące &lt;b&gt;%3&lt;/b&gt; utwory:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1029"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1033"/>
         <source>Merge Songs</source>
         <translation>Połącz Utwory</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1031"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1035"/>
         <source>Merge these songs.</source>
         <translation>Połącz te utwory.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1032"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1036"/>
         <source>Cancel merge operation.</source>
         <translation>Anuluj łączenie utworów.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1039"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1043"/>
         <source>Merging selected songs with &quot;%1 - %2&quot;...</source>
         <translation>Łączę wybrane utwory &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1060"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1064"/>
         <source>Could NOT copy file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Nie mogę skopiować pliku &quot;%1&quot; do &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1062"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1066"/>
         <source>File was copied successfully from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Plik został skopiowany z &quot;%1&quot; do &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1071"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1075"/>
         <source>Not all files of &quot;%1 - %2&quot; were copied. Song will not be deleted. Merging failed.</source>
         <translation>Nie wszystkie pliki &quot;%1 - %2&quot; zostały skopiowane. Utwór nie będzie usunięty. Łączenie utworów zakończone niepowodzeniem.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1106"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1110"/>
         <source>Calculating selected song ReplayGain...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1121"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1125"/>
         <source>Copy Files</source>
         <translation>Kopiowanie Plików</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1122"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1126"/>
         <source>You want to copy &lt;b&gt;%1&lt;/b&gt; files to &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</source>
         <translation>Zamierzasz skopiować &lt;b&gt;%1&lt;/b&gt; plików do &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1123"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1127"/>
         <source>Copy these files.</source>
         <translation>Skopiuj te pliki.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1124"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1128"/>
         <source>Cancel copy operation.</source>
         <translation>Anuluj kopiowanie.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1131"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1135"/>
         <source>Copy &amp; Use files for the song: &quot;%1 - %2&quot;...</source>
         <translation>Skopiuj i Użyj pliki w tym utworze: &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1165"/>
         <source>Including new songs to database...</source>
         <translation>Dodawanie nowych utworów do bazy tanych...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1179"/>
         <source>Invalid song file found: &quot;%1&quot;. Cannot include those.</source>
         <translation>Znaleziono błędny plik utworu: &quot;%1&quot;. Nie mogę go dodać. </translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1184"/>
         <source>Cannot include license files as songs: &quot;%1&quot;</source>
         <translation>Nie mogę dodać pliku licencji jako utwór: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1191"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1195"/>
         <source>Could not copy song file &quot;%1&quot; to new song directory &quot;%2&quot;!</source>
         <translation>Nie mogę skopiować utworu &quot;%1&quot; do nowego katalogu &quot;%2&quot;!</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1199"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1203"/>
         <source>New song included to your song collection: &quot;%1 - %2&quot;.</source>
         <translation>Dodano nowy utwór do Twojej kolekcji: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1238"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1242"/>
         <source>Could not create directory: &quot;%1&quot;. Disk full?</source>
         <translation>Nie mogę utworzyć katalogu: &quot;%1&quot;. Zapełniony dysk?</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1303"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1307"/>
         <source>Saving selected songs...</source>
         <translation>Zapisywanie wybranych utworów...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1349"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1353"/>
         <source>Open externally</source>
         <translation>Otwórz poza programem</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1354"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1358"/>
         <source>Refresh</source>
         <translation>Odświerz</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
         <source>Get Covers...</source>
         <translation>Zdobądź okładki...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1372"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
         <source>Calculate Song ReplayGain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1379"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1383"/>
         <source>Open With Finder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1382"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
         <source>Open With File Manager...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
         <source>Search for cover on AlbumArtExchange...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
         <source>Search for cover on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1391"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
         <source>Search for artwork on Fanart...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
         <source>Search for background on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1397"/>
         <source>Search for video on Google Video...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1398"/>
         <source>Search for video on Youtube...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1399"/>
         <source>Look up on Hitparade.ch...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
         <source>Look up on USDB...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1404"/>
         <source>Create Duet From Song Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1427"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1431"/>
         <source>Delete File</source>
         <translation>Usuń Plik</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1428"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1432"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; will be deleted permanently. You cannot undo a delete operation.</source>
         <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; - Ten plik zostanie usunięty. Tej operacji nie będzie można cofnąć.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1429"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1433"/>
         <source>Delete this file.</source>
         <translation>Usuń ten plik.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1435"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1439"/>
         <source>The file &quot;%1&quot; was deleted successfully.</source>
         <translation>Plik &quot;%1&quot; został usunięty.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1437"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1441"/>
         <source>The file &quot;%1&quot; was NOT deleted.</source>
         <translation>Plik &quot;%1&quot; NIE został usunięty.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1474"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1478"/>
         <source>You can only display the lyrics of one song at a time.</source>
         <translation>W tym samym czasie można przeglądać tekst tylko jednej piosenki.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1484"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1488"/>
         <source>You can only edit the lyrics of one song at a time.</source>
         <translation>Możesz tylko edytować tekst jednej piosenki w tym samym czasie.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1506"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1510"/>
         <source>Removing current filter...</source>
         <translation>Usuwanie filtrowania...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1570"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1595"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1618"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1641"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1664"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1686"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1706"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1728"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1574"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1599"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1645"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1668"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1690"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1710"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1732"/>
         <source>You can only look up one song at a time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
         <source>Shows the number of singable syllables per second. No freestyle or pauses included.</source>
         <translation>Wyświetla liczbę śpiewanych sylab na sekundę. Nie dotyczy to pauz oraz nutek freestyleowych.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1375"/>
         <source>Calculate Song Speed</source>
         <translation>Wylicz Prędkość Utworu</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1380"/>
         <source>Open With Explorer...</source>
         <translation>Otwórz W Eksploratorze...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1384"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1388"/>
         <source>Find More From Artist</source>
         <translation>Znajdź Więcej Tego Wykonawcy</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="647"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="649"/>
         <source>Time &amp;&amp; Speed</source>
         <translation>Czas I Prędkość</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="650"/>
         <source>Types</source>
         <translation>Typy</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1085"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1089"/>
         <source>Calculate selected song speeds...</source>
         <translation>Wylicz prędkości wybranych utworów...</translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.pt.ts
+++ b/src/resources/lang/UltraStar-Manager.pt.ts
@@ -5262,32 +5262,32 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">&quot;%1&quot; não suportado. Utilizando padrão para %2 no ficheiro da canção: &quot;%3&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="228"/>
+        <location filename="../../song/QUSongFile.cpp" line="238"/>
         <source>Encoding mismatch. Defaulting to %1 for song file: &quot;%2&quot;</source>
         <translation>Codificação incompativél. Restaurado para %1 na canção: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="233"/>
+        <location filename="../../song/QUSongFile.cpp" line="243"/>
         <source>&quot;%1&quot; unsupported. Defaulting to %2 for song file: &quot;%3&quot;</source>
         <translation>&quot;%1&quot; não suportado. Restaurado para %2 na canção: &quot;%3&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="357"/>
+        <location filename="../../song/QUSongFile.cpp" line="367"/>
         <source>Deprecated tag information detected.</source>
         <translation>Informação de etiqueta obsoleta detectada.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="358"/>
+        <location filename="../../song/QUSongFile.cpp" line="368"/>
         <source>The number of available tags in your configuration and that one this application offers are different.</source>
         <translation>O número de etiquetas disponíveis na sua configuração e que esta aplicação oferece são diferentes.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="359"/>
+        <location filename="../../song/QUSongFile.cpp" line="369"/>
         <source>The tag order was reset to its default order. Check out the options to set up your custom order again.</source>
         <translation>A ordem das etiquetas foi reposta à sua ordem padrão. Confira as opções para configurar a sua ordem personalizada novamente.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="709"/>
+        <location filename="../../song/QUSongFile.cpp" line="719"/>
         <source>Save error! The song file &quot;%1&quot; was NOT saved.</source>
         <translation>Erro ao guardar! O ficheiro da canção &quot;%1&quot; não foi guardado.</translation>
     </message>
@@ -5296,331 +5296,336 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Codificação de saída%1 não é suficiente. Usando UTF8 para o ficheiro da canção: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="768"/>
+        <location filename="../../song/QUSongFile.cpp" line="775"/>
         <source>The song file &quot;%1&quot; was saved successfully.</source>
         <translation>O ficheiro da canção &quot;%1&quot; foi guardado com sucesso.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="785"/>
+        <location filename="../../song/QUSongFile.cpp" line="792"/>
         <source>Old name and new name match: &quot;%1&quot;</source>
         <translation>Novo nome e antigo são iguais: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="810"/>
+        <location filename="../../song/QUSongFile.cpp" line="817"/>
         <source>Could NOT rename the song directory &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível renomear o directório de canções de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="818"/>
+        <location filename="../../song/QUSongFile.cpp" line="825"/>
         <source>Song directory renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Directório de canções renomeado de: &quot;%1&quot; para: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="829"/>
+        <location filename="../../song/QUSongFile.cpp" line="836"/>
         <source>Could NOT rename the song file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível renomear o ficheiro da canção de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="836"/>
+        <location filename="../../song/QUSongFile.cpp" line="843"/>
         <source>Song file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Ficheiro da canção renomeado de: &quot;%1&quot; para: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="848"/>
+        <location filename="../../song/QUSongFile.cpp" line="855"/>
         <source>Could NOT rename the audio file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível renomear o ficheiro audio de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="853"/>
-        <location filename="../../song/QUSongFile.cpp" line="923"/>
+        <location filename="../../song/QUSongFile.cpp" line="860"/>
+        <location filename="../../song/QUSongFile.cpp" line="930"/>
         <source>Audio file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Ficheiro audio renomeado de: &quot;%1&quot; para: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="870"/>
+        <location filename="../../song/QUSongFile.cpp" line="877"/>
         <source>Could NOT rename the cover picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível renomear a imagem da capa de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="875"/>
-        <location filename="../../song/QUSongFile.cpp" line="901"/>
+        <location filename="../../song/QUSongFile.cpp" line="882"/>
+        <location filename="../../song/QUSongFile.cpp" line="908"/>
         <source>Cover picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Imagem da capa renomeada de: &quot;%1&quot; para: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="892"/>
+        <location filename="../../song/QUSongFile.cpp" line="899"/>
         <source>Could NOT rename the background picture &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível renomeara imagem de fundo de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="879"/>
-        <location filename="../../song/QUSongFile.cpp" line="897"/>
+        <location filename="../../song/QUSongFile.cpp" line="886"/>
+        <location filename="../../song/QUSongFile.cpp" line="904"/>
         <source>Background picture renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Imagem de Fundo renomeada de: &quot;%1&quot; para: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="914"/>
+        <location filename="../../song/QUSongFile.cpp" line="921"/>
         <source>Could NOT rename the video file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível renomear o ficheiro de video de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="857"/>
-        <location filename="../../song/QUSongFile.cpp" line="919"/>
+        <location filename="../../song/QUSongFile.cpp" line="864"/>
+        <location filename="../../song/QUSongFile.cpp" line="926"/>
         <source>Video file renamed from: &quot;%1&quot; to: &quot;%2&quot;.</source>
         <translation>Ficheiro de video renomeado de: &quot;%1&quot; para: &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="933"/>
+        <location filename="../../song/QUSongFile.cpp" line="940"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for artist.</source>
         <translation>A canção &quot;%1 - %2&quot; não tem nenhum ficheiro de áudio atribuido. Não é possível usar a etiqueta ID3 para o artista.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="944"/>
+        <location filename="../../song/QUSongFile.cpp" line="951"/>
         <source>The audio file %1 does not contain ID3 tag information about an artist.</source>
         <translation>O ficheiro de áudio%1 não contém informações da etiqueta ID3 sobre artista.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="949"/>
+        <location filename="../../song/QUSongFile.cpp" line="956"/>
         <source>ID3 tag of &quot;%1&quot; used for artist. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Etiqueta ID3 de &quot;%1&quot; utilizada para artista. Alterado de: &quot;%2&quot; para: &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="954"/>
+        <location filename="../../song/QUSongFile.cpp" line="961"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for title.</source>
         <translation>A canção &quot;%1 - %2&quot; não tem nenhum ficheiro de áudio atribuido. Não é possível usar a etiqueta ID3 para o título.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="964"/>
+        <location filename="../../song/QUSongFile.cpp" line="971"/>
         <source>The audio file %1 does not contain ID3 tag information about a title.</source>
         <translation>O ficheiro de áudio%1 não contém informações da etiqueta ID3 sobre título.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="969"/>
+        <location filename="../../song/QUSongFile.cpp" line="976"/>
         <source>ID3 tag of &quot;%1&quot; used for title. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Etiqueta ID3 de &quot;%1&quot; utilizada para título. Alterado de: &quot;%2&quot; para: &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="974"/>
+        <location filename="../../song/QUSongFile.cpp" line="981"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for genre.</source>
         <translation>A canção &quot;%1 - %2&quot; não tem nenhum ficheiro de áudio atribuido. Não é possível usar a etiqueta ID3 para o gênero.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="984"/>
+        <location filename="../../song/QUSongFile.cpp" line="991"/>
         <source>The audio file %1 does not contain ID3 tag information about a genre.</source>
         <translation>O ficheiro de áudio%1 não contém informações da etiqueta ID3 sobre gênero.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="989"/>
+        <location filename="../../song/QUSongFile.cpp" line="996"/>
         <source>ID3 tag of &quot;%1&quot; used for genre. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Etiqueta ID3 de &quot;%1&quot; utilizada para gênero. Alterado de: &quot;%2&quot; para: &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="994"/>
+        <location filename="../../song/QUSongFile.cpp" line="1001"/>
         <source>The song &quot;%1 - %2&quot; has no audio file assigned. Cannot use ID3 tag for year.</source>
         <translation>A canção &quot;%1 - %2&quot; não tem nenhum ficheiro de áudio atribuido. Não é possível usar a etiqueta ID3 para ano.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1004"/>
+        <location filename="../../song/QUSongFile.cpp" line="1011"/>
         <source>The audio file %1 does not contain ID3 tag information about a year.</source>
         <translation>O ficheiro de áudio%1 não contém informações da etiqueta ID3 sobre ano.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1009"/>
+        <location filename="../../song/QUSongFile.cpp" line="1016"/>
         <source>ID3 tag of &quot;%1&quot; used for year. Changed from: &quot;%2&quot; to: &quot;%3&quot;.</source>
         <translation>Etiqueta ID3 de &quot;%1&quot; utilizada para ano. Alterado de: &quot;%2&quot; para: &quot;%3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1014"/>
+        <location filename="../../song/QUSongFile.cpp" line="1021"/>
         <source>The song &quot;%1 - %2&quot; has no unsupported tags.</source>
         <translation>A canção &quot;%1 - %2&quot; não tem etiquetas não suportadas.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1022"/>
+        <location filename="../../song/QUSongFile.cpp" line="1029"/>
         <source>Unsupported tag removed: #%1.</source>
         <translation>Etiquetas não suportadas removidas: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1024"/>
+        <location filename="../../song/QUSongFile.cpp" line="1031"/>
         <source>Unsupported tag skipped: #%1.</source>
         <translation>Etiquetas não suportadas ignoradas: #%1.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1045"/>
+        <location filename="../../song/QUSongFile.cpp" line="1052"/>
         <source>Assigned &quot;%1&quot; as audio file for &quot;%2 - %3&quot;.</source>
         <translation>Atribuído &quot;%1&quot; como ficheiro de audio para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1040"/>
+        <location filename="../../song/QUSongFile.cpp" line="1047"/>
         <source>Assigned &quot;%1&quot; as video file for &quot;%2 - %3&quot;.</source>
         <translation>Atribuído &quot;%1&quot; como ficheiro de vídeo para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="204"/>
+        <location filename="../../song/QUSongFile.cpp" line="198"/>
+        <source>Failed to detect line endings in file &quot;%1&quot;, defaulting to CRLF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../song/QUSongFile.cpp" line="214"/>
         <source>UTF8 detected in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="217"/>
+        <location filename="../../song/QUSongFile.cpp" line="227"/>
         <source>ENCODING:CP1252 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="222"/>
+        <location filename="../../song/QUSongFile.cpp" line="232"/>
         <source>ENCODING:CP1250 found in song file: &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="242"/>
+        <location filename="../../song/QUSongFile.cpp" line="252"/>
         <source>Not a valid UTF8 file and ENCODING tag missing. Defaulting to %1 in song file: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1053"/>
+        <location filename="../../song/QUSongFile.cpp" line="1060"/>
         <source>Assigned &quot;%1&quot; as cover picture for &quot;%2 - %3&quot;.</source>
         <translation>Atribuído &quot;%1&quot; como imagem de capa para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1056"/>
+        <location filename="../../song/QUSongFile.cpp" line="1063"/>
         <source>Assigned &quot;%1&quot; as background picture for &quot;%2 - %3&quot;.</source>
         <translation>Atribuído &quot;%1&quot; como imagem de fundo para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1071"/>
+        <location filename="../../song/QUSongFile.cpp" line="1078"/>
         <source>Could not copy the file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível copiar o ficheiro &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1075"/>
+        <location filename="../../song/QUSongFile.cpp" line="1082"/>
         <source>The file &quot;%1&quot; was successfully copied to &quot;%2&quot;.</source>
         <translation>O ficheiro &quot;%1&quot; foi copiado com sucesso para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1107"/>
+        <location filename="../../song/QUSongFile.cpp" line="1114"/>
         <source>File removed successfully: &quot;%1&quot;.</source>
         <translation>Ficheiro removido com sucesso: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1109"/>
+        <location filename="../../song/QUSongFile.cpp" line="1116"/>
         <source>File COULD NOT be removed: &quot;%1&quot;.</source>
         <translation>Não foi possível remover o ficheiro: &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1120"/>
+        <location filename="../../song/QUSongFile.cpp" line="1127"/>
         <source>Audio file tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta de audio removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1124"/>
+        <location filename="../../song/QUSongFile.cpp" line="1131"/>
         <source>Cover tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta da capa removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1128"/>
+        <location filename="../../song/QUSongFile.cpp" line="1135"/>
         <source>Background tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta do fundo removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1133"/>
+        <location filename="../../song/QUSongFile.cpp" line="1140"/>
         <source>Video tag removed for &quot;%1 - %2&quot;.</source>
         <translation>Etiqueta de video removida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1147"/>
+        <location filename="../../song/QUSongFile.cpp" line="1154"/>
         <source>Old path and new path match! Cannot change song path to: &quot;%1&quot;</source>
         <translation>Antigo caminho corresponde aor novo caminho! Não pode mudar caminho da canção: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1152"/>
+        <location filename="../../song/QUSongFile.cpp" line="1159"/>
         <source>Could not create new song path: &quot;%1&quot;</source>
         <translation>Não foi possível criar o novo caminho da canção: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1166"/>
+        <location filename="../../song/QUSongFile.cpp" line="1173"/>
         <source>Failed to move &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Falha ao mover &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1169"/>
+        <location filename="../../song/QUSongFile.cpp" line="1176"/>
         <source>The file &quot;%1&quot; was successfully moved to &quot;%2&quot;.</source>
         <translation>O ficheiro &quot;%1&quot; foi movido com sucesso para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1173"/>
+        <location filename="../../song/QUSongFile.cpp" line="1180"/>
         <source>Could NOT move all files of the song &quot;%2&quot; to a new location. Check out &quot;%1&quot; for the files which were copied.</source>
         <translation>Não foi possível mover todos os ficheiros da canção &quot;%2&quot; para um novo local. Verificar &quot;%1&quot; para os ficheiros que foram copiados.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1183"/>
+        <location filename="../../song/QUSongFile.cpp" line="1190"/>
         <source>Could not remove old, empty folder &quot;%1&quot;. Please do it manually.</source>
         <translation>Não foi possível remover o antigo, esvaziar a pasta &quot;%1&quot;. Por favor, faça-o manualmente.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1190"/>
+        <location filename="../../song/QUSongFile.cpp" line="1197"/>
         <source>Location of song &quot;%1 - %2&quot; successfully changed to &quot;%3&quot; in your UltraStar song folder.</source>
         <translation>Localização da canção &quot;%1 - %2&quot; alterada com sucesso para &quot;%3&quot; na sua pasta de canções UltraStar.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1201"/>
+        <location filename="../../song/QUSongFile.cpp" line="1208"/>
         <source>Could not fix audio length because no audio file is present: &quot;%1 - %2&quot;</source>
         <translation>Não foi possível corrigir comprimento de áudio, porque nenhum ficheiro de áudio está presente: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1212"/>
+        <location filename="../../song/QUSongFile.cpp" line="1219"/>
         <source>Could not fix audio length because audio file is shorter than song: &quot;%1 - %2&quot;</source>
         <translation>Não foi possível corrigir comprimento de áudio, porque é mais curto do que música: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1219"/>
+        <location filename="../../song/QUSongFile.cpp" line="1226"/>
         <source>Could not fix audio length because new value for #END would be greater than length of audio file: &quot;%1 - %2&quot;</source>
         <translation>Não foi possível corrigir comprimento de áudio, porque novo valor para etiqueta #END seria maior do que o comprimento do ficheiro de áudio: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1226"/>
+        <location filename="../../song/QUSongFile.cpp" line="1233"/>
         <source>Audio length was fixed for song &quot;%1 - %2&quot;. #END changed to: %3</source>
         <translation>Comprimento de áudio foi fixado para a canção &quot;%1 - %2&quot;. Etiqueta #END alterada para: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1241"/>
+        <location filename="../../song/QUSongFile.cpp" line="1248"/>
         <source>#GAP changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>#GAP passou de %1 a %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1250"/>
+        <location filename="../../song/QUSongFile.cpp" line="1257"/>
         <source>The tag #END was removed for: &quot;%1 - %2&quot;</source>
         <translation>Etiqueta #END removida para: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1262"/>
+        <location filename="../../song/QUSongFile.cpp" line="1269"/>
         <source>INCONSISTENT STATE! The song &quot;%1 - %2&quot; has unsaved changes and its persistent song file &quot;%3&quot; was modified externally. Save your changes or rebuild the tree manually.</source>
         <translation>Estado inconsistente! A canção &quot;%1 - %2&quot; tem alterações não guardadas e o seu ficheiro da canção &quot;%3&quot; foi modificado externamente. Guarde as suas alterações ou reconstruir a listagem manualmente.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1268"/>
+        <location filename="../../song/QUSongFile.cpp" line="1275"/>
         <source>Song file changed: &quot;%1&quot;</source>
         <translation>Ficheiro da canção alterado: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1444"/>
+        <location filename="../../song/QUSongFile.cpp" line="1451"/>
         <source>Primary song file changed from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Ficheiro da canção primário passou de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1508"/>
+        <location filename="../../song/QUSongFile.cpp" line="1515"/>
         <source>Error while preparing lyrics for %1 - %2. Could not parse the following line: %3</source>
         <translation>Erro ao preparar letras para %1 - %2. Não foi possível analisar a seguinte linha: %3</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1521"/>
+        <location filename="../../song/QUSongFile.cpp" line="1528"/>
         <source>Error while preparing lyrics for %1 - %2. Songs may not start with a line break.</source>
         <translation>Erro ao preparar letras para %1 - %2. As canções não podem começar com uma quebra de linha.</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1545"/>
+        <location filename="../../song/QUSongFile.cpp" line="1552"/>
         <source>Line too short: &quot;%1&quot;</source>
         <translation>Linha muito curta: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../song/QUSongFile.cpp" line="1601"/>
+        <location filename="../../song/QUSongFile.cpp" line="1608"/>
         <source>More than one score file found for &quot;%1 - %2&quot;. Only one will be used.</source>
         <translation>Mais de um ficheiro de pontuação encontrado para &quot;%1 - %2&quot;. Apenas um será usado.</translation>
     </message>
@@ -5832,7 +5837,17 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="144"/>
+        <source>Line Endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../songtree/QUSongTree.cpp" line="145"/>
+        <source>Shows whether the text file has CRLF or LF line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
         <source>Song</source>
         <translation>Canção</translation>
     </message>
@@ -5841,12 +5856,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Comprimento da canção calculado pelo BPM e letra.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="150"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="152"/>
         <source>Indicates a problem with the difference of &lt;i&gt;song length&lt;/i&gt; and &lt;i&gt;audio length&lt;/i&gt;.&lt;br&gt;&lt;br&gt;The tooltip shows the difference.</source>
         <translation>Indica um problema com a diferença de &lt;i&gt;duração da canção&lt;/i&gt; e &lt;i&gt; comprimento de áudio &lt;/i&gt;.&lt;br&gt;&lt;br&gt;A dica mostra a diferença.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="153"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
@@ -5863,17 +5878,17 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Mostra o comprimento efectivo:&lt;br&gt;&lt;b&gt;comprimento de áudio - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="163"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
         <source>Shows the number of singable syllables per second. No freestyle or pauses included.</source>
         <translation>Mostra o número de sílabas por segundo cantáveis​​. Não incluídas sílabas freestyle ou pausas.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="165"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
         <source>Start</source>
         <translation>Inicio</translation>
     </message>
@@ -5882,7 +5897,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Ignorar os primeiros segundos da canção.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="168"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
         <source>End</source>
         <translation>Fim</translation>
     </message>
@@ -5891,7 +5906,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Repor o tamanho do ficheiro de áudio.&lt;br&gt;&lt;i&gt;(em milisegundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="171"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
         <source>Videogap</source>
         <translation>Videogap</translation>
     </message>
@@ -5900,7 +5915,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Ignorar os primeiros segundos do vídeo.&lt;br&gt;&lt;br&gt;&lt;i&gt;Use valores negativos ou positivos em &lt;b&gt;#START&lt;/b&gt; para corrigir um ficheiro de vídeo de curta duração.&lt;/I&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="167"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="169"/>
         <source>Shows how much time is skipped from the beginning of the audio file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Mostra quanto tempo é ignorado desde o início do ficheiro de áudio.&lt;br&gt;&lt;i&gt;(em segundos)&lt;/i&gt;</translation>
     </message>
@@ -5909,12 +5924,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Mostra quanto tempo é ignorado a partir do final do ficheiro de áudio.&lt;br&gt;&lt;i&gt;(em milisegundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="173"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
         <source>Shows how much time is skipped from the video file.&lt;br&gt;&lt;i&gt;(in seconds)&lt;/i&gt;</source>
         <translation>Mostra quanto tempo é ignorado a partir do ficheiro de vídeo.&lt;br&gt;&lt;i&gt;(em segundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
         <source>Relative?</source>
         <translation>Relativo?</translation>
     </message>
@@ -5923,7 +5938,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Tem timestamps relativos.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="177"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
         <source>BPM</source>
         <translation>BPM</translation>
     </message>
@@ -5932,7 +5947,7 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Batidas por minuto</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
         <source>GAP</source>
         <translation>GAP</translation>
     </message>
@@ -5941,495 +5956,495 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">Tempo até à primeira sílaba.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="147"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="149"/>
         <source>Shows the song length calculated from BPM and lyrics.</source>
         <translation>Mostra o comprimento da canção calculado pelo BPM e letra.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="155"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
         <source>Shows the length of audio file, if present.&lt;br&gt;&lt;br&gt;Can be reset through &lt;b&gt;#END&lt;/b&gt; tag.</source>
         <translation>Mostra o comprimento do ficheiro audio, se presente.&lt;br&gt;&lt;br&gt;Pode ser redefinido através da etiqueta &lt;b&gt;#END&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="157"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
         <source>Effective</source>
         <translation>Efectivo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="159"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="161"/>
         <source>Shows the effective song length:&lt;br&gt;&lt;b&gt;audio length - #START&lt;/b&gt;.</source>
         <translation>Mostra o comprimento efectivo da canção:&lt;br&gt;&lt;b&gt;comprimento audio - #START&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="170"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="172"/>
         <source>Shows when the song playback stops.&lt;br&gt;&lt;i&gt;(in &lt;b&gt;milli&lt;/b&gt;seconds)&lt;/i&gt;</source>
         <translation>Mostra quando a reprodução da canção pára.&lt;br&gt;&lt;i&gt;(em &lt;b&gt;milli&lt;/b&gt;segundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="176"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="178"/>
         <source>Shows whether the song has relative timestamps.</source>
         <translation>Mostra quando a canção tem tempos relativos.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="179"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="181"/>
         <source>Shows the song tempo.&lt;br&gt;&lt;i&gt;(in beats per 15 seconds)</source>
         <translation>Mostra o andamento da canção.&lt;br&gt;&lt;i&gt;(em batidas por 15 segundos)</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="182"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="184"/>
         <source>Shows the gap between the beginning of the song and the first syllable.&lt;br&gt;&lt;i&gt;(in milliseconds)&lt;/i&gt;</source>
         <translation>Mostra a diferença entre o início da canção e a primeira sílaba.&lt;br&gt;&lt;i&gt;(em milisegundos)&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="185"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="187"/>
         <source>Indicate duplicate songs. &lt;b&gt;You should not see me.&lt;/b&gt;</source>
         <translation>Indica canções duplicadas. &lt;b&gt;Você nao me deve ver.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="323"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="325"/>
         <source>Saving unsaved changes...</source>
         <translation>Guardando alterações não guardadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="394"/>
         <source>Filter removed. All songs are visible now.</source>
         <translation>Filtro removido. Agora todas as canções estão visiveis.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="404"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="406"/>
         <source>Applying filter...</source>
         <translation>Aplicando filtro...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>Filter applied: &quot;%1&quot;%2</source>
         <translation>Filtro aplicado: &quot;%1&quot;%2</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="497"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="499"/>
         <source>, negated</source>
         <translation>, negado</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="517"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="519"/>
         <source>Looking for duplicate songs...</source>
         <translation>Procurando por canções duplicadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="568"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
         <source>Filter applied. Duplicates for %1 songs found.</source>
         <translation>Filtro aplicado. Encontradas %1 canções duplicadas.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="570"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="572"/>
         <source>No duplicate songs found.</source>
         <translation>Não foram encontradas canções duplicadas.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="619"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
         <source>Hide</source>
         <translation>Esconder</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="621"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
         <source>Selected Songs</source>
         <translation>Canções seleccionadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="624"/>
         <source>Selected Songs Only</source>
         <translation>Apenas canções seleccionadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="623"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
         <source>Unselected Songs</source>
         <translation>Canções não seleccionadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="625"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="637"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="627"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
         <source>All</source>
         <translation>Todas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="626"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="628"/>
         <source>None</source>
         <translation>Nenhuma</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="636"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
         <source>Presets</source>
         <translation>Predefinições</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="638"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="640"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="639"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
         <source>Minimum</source>
         <translation>Mínimo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="641"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="643"/>
         <source>Spell &amp;&amp; File Checking</source>
         <translation>Ortografia &amp;&amp; Verificar ficheiro</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="642"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="644"/>
         <source>Time Comparison</source>
         <translation>Comparação de tempo</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="646"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
         <source>Custom Tags</source>
         <translation>Etiquetas personalizadas</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="647"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="649"/>
         <source>Time &amp;&amp; Speed</source>
         <translation>Tempo &amp;&amp; Velocidade</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="648"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="650"/>
         <source>Types</source>
         <translation>Tipos</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="856"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="860"/>
         <source>Hiding all visible songs...</source>
         <translation>Esconder todas as canções visiveis...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="879"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
         <source>Could not hide any item.</source>
         <translation>Não foi possível esconder qualquer item.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="883"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="887"/>
         <source>Hiding selected songs...</source>
         <translation>Escondendo canções seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="898"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="902"/>
         <source>%1 songs added to list of invisible songs.</source>
         <translation>%1 canções adicionadas à lista de canções invisiveis.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="923"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="927"/>
         <source>%1 songs are visible now.</source>
         <translation>%1 canções são visiveis.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="950"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="954"/>
         <source>All files in the song directory will be deleted including the directory itself if it is not empty.&lt;br&gt;&lt;br&gt;You want to delete the following &lt;b&gt;%1&lt;/b&gt; songs:</source>
         <translation>Todos os ficheiros no directório de canções será eliminado, incluindo o próprio directório, se ele não está vazio.&lt;br&gt;&lt;br&gt;Você deseja eliminar as seguintes &lt;b&gt;%1&lt;/b&gt; canções:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="963"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="967"/>
         <source>Delete Songs</source>
         <translation>Eliminar canções</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="965"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="969"/>
         <source>Delete these songs.</source>
         <translation>Eliminar estas canções.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="966"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1430"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="970"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1434"/>
         <source>Cancel delete operation.</source>
         <translation>Cancelar operação de eliminar.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="973"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="977"/>
         <source>Deleting selected songs...</source>
         <translation>Eliminando canções seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1003"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1007"/>
         <source>Too few songs selected. You have to merge at least 2 songs.</source>
         <translation>Muito poucas canções seleccionadas. Você tem de juntar pelo menos 2 canções.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1016"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1020"/>
         <source>You want to merge songs with &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. All files of the other songs will be moved to that song&apos;s path.&lt;br&gt;&lt;br&gt;The following &lt;b&gt;%3&lt;/b&gt; songs will disappear:</source>
         <translation>Você deseja juntar as canções com &lt;b&gt;&quot;%1 - %2&quot;&lt;/b&gt;. Todos os ficheiros das outras canções serão movidos para o caminho desta canção.&lt;br&gt;&lt;br&gt; A seguiintes &lt;b&gt;%3&lt;/b&gt; canções desaparecerão:</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1029"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1033"/>
         <source>Merge Songs</source>
         <translation>Juntar Canções</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1031"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1035"/>
         <source>Merge these songs.</source>
         <translation>Juntar estas canções.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1032"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1036"/>
         <source>Cancel merge operation.</source>
         <translation>Cancelar operação de juntar.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1039"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1043"/>
         <source>Merging selected songs with &quot;%1 - %2&quot;...</source>
         <translation>Juntando canções seleccionadas com &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1060"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1064"/>
         <source>Could NOT copy file &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Não foi possível copiar o ficheiro &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1062"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1066"/>
         <source>File was copied successfully from &quot;%1&quot; to &quot;%2&quot;.</source>
         <translation>Ficheiro foi copiado com sucesso de &quot;%1&quot; para &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1071"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1075"/>
         <source>Not all files of &quot;%1 - %2&quot; were copied. Song will not be deleted. Merging failed.</source>
         <translation>Nem todos os ficheiros de &quot;%1 - %2&quot; foram copiados. Canção não será apagado. Junção falhou.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1085"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1089"/>
         <source>Calculate selected song speeds...</source>
         <translation>Calcular velocidade das canções seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1106"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1110"/>
         <source>Calculating selected song ReplayGain...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1121"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1125"/>
         <source>Copy Files</source>
         <translation>Copiar Ficheiros</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1122"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1126"/>
         <source>You want to copy &lt;b&gt;%1&lt;/b&gt; files to &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</source>
         <translation>Você quer copiar os ficheiros de &lt;b&gt;%1&lt;/b&gt; para &lt;b&gt;&quot;%2&quot;&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1123"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1127"/>
         <source>Copy these files.</source>
         <translation>Copiar estes ficheiros.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1124"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1128"/>
         <source>Cancel copy operation.</source>
         <translation>Cancelar operação de copiar.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1131"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1135"/>
         <source>Copy &amp; Use files for the song: &quot;%1 - %2&quot;...</source>
         <translation>Copiar &amp; Usar ficheiros para a canção: &quot;%1 - %2&quot;...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1161"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1165"/>
         <source>Including new songs to database...</source>
         <translation>Incluindo novas canções à base de dados...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1175"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1179"/>
         <source>Invalid song file found: &quot;%1&quot;. Cannot include those.</source>
         <translation>Ficheiro de canção inválida encontrado: &quot;%1&quot;. Impossível incluir.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1180"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1184"/>
         <source>Cannot include license files as songs: &quot;%1&quot;</source>
         <translation>Não pode incluir ficheiros de licença como canções: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1191"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1195"/>
         <source>Could not copy song file &quot;%1&quot; to new song directory &quot;%2&quot;!</source>
         <translation>Não foi possível copiar ficheiro da canção &quot;%1&quot; para o directório da nova canção &quot;%2&quot;!</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1199"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1203"/>
         <source>New song included to your song collection: &quot;%1 - %2&quot;.</source>
         <translation>Nova canção incluída na sua colecção: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1238"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1242"/>
         <source>Could not create directory: &quot;%1&quot;. Disk full?</source>
         <translation>Não foi possível criar directório: &quot;%1&quot;. Disco cheio?</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1258"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1262"/>
         <source>Refreshing selected songs...</source>
         <translation>Actualizando canções seleccionadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1303"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1307"/>
         <source>Saving selected songs...</source>
         <translation>Guardando canções actualizadas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1336"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1340"/>
         <source>Show preview</source>
         <translation>Mostrar Pré-Visualização</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1337"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
         <source>Open image file externally</source>
         <translation>Abrir ficheiro de imagem externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1339"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
         <source>Open video file externally</source>
         <translation>Abrir ficheiro de video externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1341"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1345"/>
         <source>Open audio file externally</source>
         <translation>Abrir ficheiro de audio externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1343"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1347"/>
         <source>Show file contents</source>
         <translation>Mostrar o conteúdo do ficheiro</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1344"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1348"/>
         <source>Open text file externally</source>
         <translation>Abrir ficheiro de texto externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1346"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1350"/>
         <source>Set as primary song</source>
         <translation>Definir como canção principal</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1349"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1353"/>
         <source>Open externally</source>
         <translation>Abrir externamente</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1351"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1356"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1360"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1354"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1358"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1355"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1357"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1361"/>
         <source>Merge</source>
         <translation>Juntar</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1359"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
         <source>Play</source>
         <translation>Play</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1362"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
         <source>Send To Playlist</source>
         <translation>Enviar para Playlist</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1363"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
         <source>Get Covers...</source>
         <translation>Obter capas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1365"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1369"/>
         <source>Review pictures</source>
         <translation>Rever imagens</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1366"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1370"/>
         <source>Covers...</source>
         <translation>Capas...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1367"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
         <source>Backgrounds...</source>
         <translation>Fundos...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1371"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1375"/>
         <source>Calculate Song Speed</source>
         <translation>Calcular velocidade da canção</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1372"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
         <source>Calculate Song ReplayGain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1376"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1380"/>
         <source>Open With Explorer...</source>
         <translation>Abrir com o Explorer...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1379"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1383"/>
         <source>Open With Finder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1382"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
         <source>Open With File Manager...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1384"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1388"/>
         <source>Find More From Artist</source>
         <translation>Procurar mais do Artista</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1385"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
         <source>Show Lyrics...</source>
         <translation>Mostrar letra...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1386"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
         <source>Edit Lyrics...</source>
         <translation>Editar Letra...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1389"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
         <source>Search for cover on AlbumArtExchange...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1390"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
         <source>Search for cover on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1391"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
         <source>Search for artwork on Fanart...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1392"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
         <source>Search for background on Google Images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1393"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1397"/>
         <source>Search for video on Google Video...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1394"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1398"/>
         <source>Search for video on Youtube...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1395"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1399"/>
         <source>Look up on Hitparade.ch...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6438,64 +6453,64 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Localizar no Hitparade...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1396"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
         <source>Look up on USDB...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1400"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1404"/>
         <source>Create Duet From Song Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1427"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1431"/>
         <source>Delete File</source>
         <translation>Eliminar Ficheiro</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1428"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1432"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; will be deleted permanently. You cannot undo a delete operation.</source>
         <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; será eliminado permanentemente. Você não pode desfazer uma operação de eliminação.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1429"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1433"/>
         <source>Delete this file.</source>
         <translation>Eliminar este ficheiro.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1435"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1439"/>
         <source>The file &quot;%1&quot; was deleted successfully.</source>
         <translation>O ficheiro &quot;%1&quot; foi eliminado com sucesso.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1437"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1441"/>
         <source>The file &quot;%1&quot; was NOT deleted.</source>
         <translation>O ficheiro &quot;%1&quot; não foi eliminado.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1474"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1478"/>
         <source>You can only display the lyrics of one song at a time.</source>
         <translation>Você só pode exibir a letra de uma canção de cada vez.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1484"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1488"/>
         <source>You can only edit the lyrics of one song at a time.</source>
         <translation>Você apenas pode editar a letra de uma canção de cada vez.</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1506"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1510"/>
         <source>Removing current filter...</source>
         <translation>Removendo filtro actual...</translation>
     </message>
     <message>
-        <location filename="../../songtree/QUSongTree.cpp" line="1570"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1595"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1618"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1641"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1664"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1686"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1706"/>
-        <location filename="../../songtree/QUSongTree.cpp" line="1728"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1574"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1599"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1622"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1645"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1668"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1690"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1710"/>
+        <location filename="../../songtree/QUSongTree.cpp" line="1732"/>
         <source>You can only look up one song at a time.</source>
         <translation>Apenas pode localizar uma música ao mesmo tempo.</translation>
     </message>

--- a/src/song/QUSongFile.h
+++ b/src/song/QUSongFile.h
@@ -106,6 +106,7 @@ public slots:
 	QString artistonsorting() const	{return _info.value(ARTISTONSORTING_TAG,	QString(N_A));}
 	QString titleonsorting() const	{return _info.value(TITLEONSORTING_TAG,		QString(N_A));}
 	const ReplayGainInfo* rgInfo() const {return _rgInfo; }
+	LineEnding lineEnding() const override { return _lineEnding; }
 
 	QString customTag(const QString &tag) const {return _info.value(tag.toUpper(), QString(N_A));}
 
@@ -159,6 +160,7 @@ public slots:
 	void renameSongCover(const QString &newName);
 	void renameSongBackground(const QString &newName);
 	void renameSongVideo(const QString &newName);
+	void setLineEnding(LineEnding lineEnding) override { _lineEnding = lineEnding; }
 
 	void useID3TagForArtist();
 	void useID3TagForTitle();
@@ -227,6 +229,7 @@ private:
 	QStringList _lyrics;		  // lyrics
 	QStringList _footer;		  // other stuff after the end mark 'E' in the song file
 	ReplayGainInfo *_rgInfo;
+	LineEnding _lineEnding = LineEnding::CRLF;
 
 	QStringList _foundUnsupportedTags;
 	bool _hasUnsavedChanges;

--- a/src/song/QUSongInterface.h
+++ b/src/song/QUSongInterface.h
@@ -54,6 +54,11 @@ class QFileInfo;
 #define GOLDEN_NOTES			"GOLDENNOTES"
 #define RAP_NOTES				"RAPNOTES"
 
+enum class LineEnding {
+	CRLF,
+	LF
+};
+
 class QUSongNoteInterface: public QObject {
 	Q_OBJECT
 
@@ -257,6 +262,8 @@ public:
 	virtual QFileInfo backgroundFileInfo() const = 0;
 	virtual QFileInfo videoFileInfo() const = 0;
 
+	virtual LineEnding lineEnding() const = 0;
+
 	virtual void setInfo(const QString &key, const QString &value) = 0;
 
 	virtual void renameSongDir(const QString &newName) = 0;
@@ -288,6 +295,7 @@ public:
 	virtual void fixAudioLength(int buffer) = 0;
 	virtual void roundGap() = 0;
 	virtual void removeEndTag() = 0;
+	virtual void setLineEnding(LineEnding lineEnding) = 0;
 
 	virtual QList<QUSongLineInterface*>& loadMelody() = 0;
 	virtual void clearMelody() = 0;

--- a/src/songtree/QUSongItem.cpp
+++ b/src/songtree/QUSongItem.cpp
@@ -943,6 +943,10 @@ void QUSongItem::updateTextColumns() {
 		this->setText(FIRST_CUSTOM_TAG_COLUMN + (i),	  song()->customTag(customTag));
 		this->setToolTip(FIRST_CUSTOM_TAG_COLUMN + (i++), song()->customTag(customTag));
 	}
+
+	// line ending
+	QString lineEnding(song()->lineEnding() == LineEnding::CRLF ? "CRLF" : "LF");
+	this->setText(LINE_ENDING_COLUMN, lineEnding); this->setToolTip(LINE_ENDING_COLUMN, lineEnding);
 }
 
 void QUSongItem::updateControlColumns() {

--- a/src/songtree/QUSongItem.h
+++ b/src/songtree/QUSongItem.h
@@ -46,14 +46,15 @@
 #define YEAR_COLUMN				30
 #define CREATOR_COLUMN			31
 #define TAGS_COLUMN				32
+#define LINE_ENDING_COLUMN      33
 
-#define RELATIVE_COLUMN			33
-#define BPM_COLUMN				34
-#define GAP_COLUMN				35
+#define RELATIVE_COLUMN			34
+#define BPM_COLUMN				35
+#define GAP_COLUMN				36
 
-#define DUPLICATE_ID_COLUMN		36
+#define DUPLICATE_ID_COLUMN		37
 
-#define FIRST_CUSTOM_TAG_COLUMN	37
+#define FIRST_CUSTOM_TAG_COLUMN	38
 
 /*!
  * This class encapsulates a pointer to a QUSongFile object to be able

--- a/src/songtree/QUSongTree.cpp
+++ b/src/songtree/QUSongTree.cpp
@@ -141,6 +141,8 @@ void QUSongTree::initHorizontalHeader() {
 	header->setIcon(CREATOR_COLUMN, QIcon(":/types/creator.png"));
 	header->setText(TAGS_COLUMN, tr("Tags"));
 	header->setIcon(TAGS_COLUMN, QIcon(":/types/tags.png"));
+	header->setText(LINE_ENDING_COLUMN, tr("Line Endings"));
+	header->setToolTip(LINE_ENDING_COLUMN, tr("Shows whether the text file has CRLF or LF line endings"));
 
 	header->setText(LENGTH_COLUMN, tr("Song"));
 	header->setIcon(LENGTH_COLUMN, QIcon(":/types/time_song.png"));
@@ -741,6 +743,8 @@ void QUSongTree::showDefaultColumns(bool save) {
 	this->header()->showSection(YEAR_COLUMN);
 	this->header()->showSection(CREATOR_COLUMN);
 	this->header()->showSection(TAGS_COLUMN);
+	this->header()->showSection(LINE_ENDING_COLUMN);
+
 
 	int customTagsCount = QUSongSupport::availableCustomTags().size();
 	for(int i = 0; i < customTagsCount; ++i)


### PR DESCRIPTION
This PR makes the following changes:
- Automatically detect if a text file has CRLF or LF line endings. When writing changes to a file, preserve the file's existing line ending. Previously, the Manager would always use the default system line ending. This could result in changing the file's line ending type without user's permission
- Add a column in the song tree which indicates if the text file has CRLF or LF line endings
- Add a preparatory task which converts line endings according to user preference (see screenshot below)
<img width="459" height="547" alt="screenshot" src="https://github.com/user-attachments/assets/adae0152-792d-4005-88ed-555e7e9b6289" />
