### PR TITLE
Fix Display of Rap Notes in Media Player

### DIFF
--- a/src/mediaplayer/QUAutoCue.cpp
+++ b/src/mediaplayer/QUAutoCue.cpp
@@ -57,6 +57,7 @@ void QUAutoCue::reset(const QList<QUSongLineInterface*> &lines, double bpm, doub
 
 			setFontWeight(QFont::Normal);
 			setFontItalic(false);
+			setFontUnderline(false);
 
 			_cueList << QUCueInfo(time, pos, note->syllable().size(), lineNumber);
 


### PR DESCRIPTION
The media player uses an underline to represent rap notes in the lyrics. However, the underline is not reset after each syllable. The result is that after the first rap note is encountered, the entire rest of the lyrics are underlined. See screenshot below. This PR fixes the issue.

<img width="420" height="451" alt="Screenshot" src="https://github.com/user-attachments/assets/bb9847fd-a0c5-4d87-b3e5-13ef0ad6fd4a" />
