### PR TITLE
Modernize Inital Path Setup

### DIFF
--- a/src/plugins/audiotag/audiotag.de.ts
+++ b/src/plugins/audiotag/audiotag.de.ts
@@ -202,76 +202,76 @@
         <translation>Bearbeite &quot;Umbenennen&quot;-Aufgabe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Beschreibung</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>&amp;ToolTip</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Icon</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Gruppe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Exclusive Aufgabe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Ziel</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>Das Ziel bestimmt die Stelle, welche umbenannt wird.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Schema</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Speichern unter...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>

--- a/src/plugins/audiotag/audiotag.es.ts
+++ b/src/plugins/audiotag/audiotag.es.ts
@@ -223,76 +223,76 @@
         <translation>Editar tarea de renombrado</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Descripción</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>Gl&amp;obo de Sugerencia</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Ícono</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation>Taza</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Grupo</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Tarea exclusiva</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Objetivo</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>El objetivo especifica el objeto sobre el que se hará el renombrado.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>E&amp;squema</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>

--- a/src/plugins/audiotag/audiotag.fr.ts
+++ b/src/plugins/audiotag/audiotag.fr.ts
@@ -202,76 +202,76 @@
         <translation>Editer la tâche de renommage</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Description</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>Info&amp;bulle</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Icone</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation>Coupe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Groupe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Tâche exclusive</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Cible</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>La cible définit l&apos;objet sur lequel le renommage sera effectué.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Schéma</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Sauvegarder sous...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>

--- a/src/plugins/audiotag/audiotag.pl.ts
+++ b/src/plugins/audiotag/audiotag.pl.ts
@@ -202,76 +202,76 @@
         <translation>Zmień lub Przemianuj Zadania</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Opis</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>P&amp;odpowiedź</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Ikona</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation>Puchar</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Grupa</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Zadanie Priorytetowe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Cel</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>Cel wskazuje na obiekt którego nazwa zostanie zmieniona.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Schemat</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Zapisz Jako...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>

--- a/src/plugins/audiotag/audiotag.pt.ts
+++ b/src/plugins/audiotag/audiotag.pt.ts
@@ -203,76 +203,76 @@
         <translation>Editar Tarefa Renomear</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Descrição</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>&amp;Ferramentas</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Icon</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation>Taça</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Grupo</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Tarefa exclusiva</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Target</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>A target especifica o objecto no qual a mudança de nome será feito.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Esquema</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>

--- a/src/plugins/cleanup/cleanup.de.ts
+++ b/src/plugins/cleanup/cleanup.de.ts
@@ -4,50 +4,180 @@
 <context>
     <name>QUCleanUpTask</name>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="13"/>
+        <location filename="QUCleanUpTask.cpp" line="28"/>
         <source>Delete unused files</source>
         <translation>Lösche nicht verwendete Dateien</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="14"/>
+        <location filename="QUCleanUpTask.cpp" line="29"/>
         <source>Every file which is not used by UltraStar will be deleted.&lt;br&gt;&lt;br&gt;&lt;b&gt;This cannot be undone!&lt;/b&gt;</source>
         <translation>Jede Datei, die nicht von UltraStar genutzt wird, wird gelöscht.&lt;br&gt;&lt;br&gt;&lt;b&gt;Kann nicht rückgängig gemacht werden!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="18"/>
+        <location filename="QUCleanUpTask.cpp" line="33"/>
         <source>Clear invalid file-related tags</source>
         <translation>Entferne ungültige, Datei-bezogene Tags</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="19"/>
+        <location filename="QUCleanUpTask.cpp" line="34"/>
         <source>Removes the value of invalid file-related tags so that they will not be saved into the song text file.&lt;br&gt;&lt;br&gt;This includes &lt;b&gt;#VIDEOGAP&lt;/b&gt; for invalid video files as well as &lt;b&gt;#START&lt;/b&gt; and &lt;b&gt;#END&lt;/b&gt; for invalid audio files.</source>
         <translation>Entfernt den Wert jedes ungültigen, datei-bezogenen Tags, sodass dieser nicht mehr in die Songdatei gespeichert wird.&lt;br&gt;&lt;br&gt;Dies betrifft auch &lt;b&gt;#VIDEOGAP&lt;/b&gt; für ungültige Videos, sowie &lt;b&gt;#START&lt;/b&gt; und &lt;b&gt;#END&lt;/b&gt; für ungültige Audiodateien.</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="25"/>
+        <location filename="QUCleanUpTask.cpp" line="40"/>
         <source>Remove #END tag</source>
         <oldsource>Remove #END tag.</oldsource>
         <translation>Entferne den #END-Tag</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="53"/>
+        <location filename="QUCleanUpTask.cpp" line="44"/>
+        <source>Write song info to ID3 of the audio file. This will overwrite existing info!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="100"/>
+        <source>#ARTIST written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="105"/>
+        <source>#TITLE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="110"/>
+        <source>#GENRE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="115"/>
+        <source>#YEAR written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="120"/>
+        <source>#COMMENT written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="128"/>
+        <source>#LANGUAGE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="136"/>
+        <source>#BPM written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="173"/>
+        <source>Unsychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="263"/>
+        <source>Sychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="297"/>
+        <source>Cover image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="299"/>
+        <source>Song has no cover image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="336"/>
+        <source>Background image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="338"/>
+        <source>Song has no background image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="343"/>
+        <source>Cannot write song infos to ID3 tags. The audio file type is not yet supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="354"/>
         <source>Audio files</source>
         <translation>Audiodateien</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="54"/>
+        <location filename="QUCleanUpTask.cpp" line="355"/>
         <source>Picture files</source>
         <translation>Bilddateien</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="55"/>
+        <location filename="QUCleanUpTask.cpp" line="356"/>
         <source>Video files</source>
         <translation>Videodateien</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="56"/>
+        <location filename="QUCleanUpTask.cpp" line="357"/>
         <source>Pattern:</source>
         <translation>Muster:</translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="360"/>
+        <source>Write #ARTIST to ID3 artist tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="361"/>
+        <source>Write #TITLE to ID3 title tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="362"/>
+        <source>Write #GENRE to ID3 genre tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="363"/>
+        <source>Write #YEAR to ID3 year tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="364"/>
+        <source>Write #COMMENT to ID3 comment tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="365"/>
+        <source>Write #LANGUAGE to ID3 language tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="366"/>
+        <source>Write #BPM to ID3 BPM tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="367"/>
+        <source>Write song lyrics to ID3 unsychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="368"/>
+        <source>Write song lyrics to ID3 sychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="369"/>
+        <source>Write #COVER artwork to ID3 (FrontCover) artwork tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="370"/>
+        <source>Write #BACKGROUD artwork to ID3 (Artist) artwork tag</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/plugins/cleanup/cleanup.es.ts
+++ b/src/plugins/cleanup/cleanup.es.ts
@@ -4,50 +4,180 @@
 <context>
     <name>QUCleanUpTask</name>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="13"/>
+        <location filename="QUCleanUpTask.cpp" line="28"/>
         <source>Delete unused files</source>
         <translation>Eliminar archivos sin usar</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="14"/>
+        <location filename="QUCleanUpTask.cpp" line="29"/>
         <source>Every file which is not used by UltraStar will be deleted.&lt;br&gt;&lt;br&gt;&lt;b&gt;This cannot be undone!&lt;/b&gt;</source>
         <translation>Cada archivo que no sea usado por UltraStar será eliminado.&lt;br&gt;&lt;br&gt;&lt;b&gt;¡Esto no puede deshacerse!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="18"/>
+        <location filename="QUCleanUpTask.cpp" line="33"/>
         <source>Clear invalid file-related tags</source>
         <translation>Eliminar etiquetas de archivo inválidas</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="19"/>
+        <location filename="QUCleanUpTask.cpp" line="34"/>
         <source>Removes the value of invalid file-related tags so that they will not be saved into the song text file.&lt;br&gt;&lt;br&gt;This includes &lt;b&gt;#VIDEOGAP&lt;/b&gt; for invalid video files as well as &lt;b&gt;#START&lt;/b&gt; and &lt;b&gt;#END&lt;/b&gt; for invalid audio files.</source>
         <translation>Elimina etiquetas de archivo inválidas, de modo que no sean guardadas en el archivo de texto de la canción.&lt;br&gt;&lt;br&gt;Esto incluye &lt;b&gt;#VIDEOGAP&lt;/b&gt; para archivos de video inválidos, así como también &lt;b&gt;#START&lt;/b&gt; y &lt;b&gt;#END&lt;/b&gt; para archivos de audio inválidos.</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="25"/>
+        <location filename="QUCleanUpTask.cpp" line="40"/>
         <source>Remove #END tag</source>
         <oldsource>Remove #END tag.</oldsource>
         <translation>Eliminar la etiqueta #END</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="53"/>
+        <location filename="QUCleanUpTask.cpp" line="44"/>
+        <source>Write song info to ID3 of the audio file. This will overwrite existing info!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="100"/>
+        <source>#ARTIST written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="105"/>
+        <source>#TITLE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="110"/>
+        <source>#GENRE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="115"/>
+        <source>#YEAR written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="120"/>
+        <source>#COMMENT written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="128"/>
+        <source>#LANGUAGE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="136"/>
+        <source>#BPM written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="173"/>
+        <source>Unsychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="263"/>
+        <source>Sychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="297"/>
+        <source>Cover image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="299"/>
+        <source>Song has no cover image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="336"/>
+        <source>Background image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="338"/>
+        <source>Song has no background image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="343"/>
+        <source>Cannot write song infos to ID3 tags. The audio file type is not yet supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="354"/>
         <source>Audio files</source>
         <translation>Archivos de audio</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="54"/>
+        <location filename="QUCleanUpTask.cpp" line="355"/>
         <source>Picture files</source>
         <translation>Archivos de imagen</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="55"/>
+        <location filename="QUCleanUpTask.cpp" line="356"/>
         <source>Video files</source>
         <translation>Archivos de video</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="56"/>
+        <location filename="QUCleanUpTask.cpp" line="357"/>
         <source>Pattern:</source>
         <translation>Patrón:</translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="360"/>
+        <source>Write #ARTIST to ID3 artist tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="361"/>
+        <source>Write #TITLE to ID3 title tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="362"/>
+        <source>Write #GENRE to ID3 genre tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="363"/>
+        <source>Write #YEAR to ID3 year tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="364"/>
+        <source>Write #COMMENT to ID3 comment tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="365"/>
+        <source>Write #LANGUAGE to ID3 language tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="366"/>
+        <source>Write #BPM to ID3 BPM tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="367"/>
+        <source>Write song lyrics to ID3 unsychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="368"/>
+        <source>Write song lyrics to ID3 sychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="369"/>
+        <source>Write #COVER artwork to ID3 (FrontCover) artwork tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="370"/>
+        <source>Write #BACKGROUD artwork to ID3 (Artist) artwork tag</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/plugins/cleanup/cleanup.fr.ts
+++ b/src/plugins/cleanup/cleanup.fr.ts
@@ -4,50 +4,180 @@
 <context>
     <name>QUCleanUpTask</name>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="13"/>
+        <location filename="QUCleanUpTask.cpp" line="28"/>
         <source>Delete unused files</source>
         <translation>Supprimer les fichier inutilisés</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="14"/>
+        <location filename="QUCleanUpTask.cpp" line="29"/>
         <source>Every file which is not used by UltraStar will be deleted.&lt;br&gt;&lt;br&gt;&lt;b&gt;This cannot be undone!&lt;/b&gt;</source>
         <translation>Tous les fichiers qui ne sont pas utilisés par Ultrastar vont être supprimés.&lt;br&gt;&lt;br&gt;&lt;b&gt;Ceci ne pourra pas être annulé!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="18"/>
+        <location filename="QUCleanUpTask.cpp" line="33"/>
         <source>Clear invalid file-related tags</source>
         <translation>Nettoyer les champs pointant vers des fichiers invalides</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="19"/>
+        <location filename="QUCleanUpTask.cpp" line="34"/>
         <source>Removes the value of invalid file-related tags so that they will not be saved into the song text file.&lt;br&gt;&lt;br&gt;This includes &lt;b&gt;#VIDEOGAP&lt;/b&gt; for invalid video files as well as &lt;b&gt;#START&lt;/b&gt; and &lt;b&gt;#END&lt;/b&gt; for invalid audio files.</source>
         <translation>Enlève les valeurs incorrectes pointant vers des fichiers invalides, ainsi ils ne seront plus inclus dans le fichier texte de la chanson.&lt;br&gt;&lt;br&gt;Ceci inclus &lt;b&gt;#VIDEOGAP&lt;/b&gt; pour les fichiers vidéo invalides ainsi que &lt;b&gt;#START&lt;/b&gt; et &lt;b&gt;#END&lt;/b&gt; pour les fichiers audio invalides.</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="25"/>
+        <location filename="QUCleanUpTask.cpp" line="40"/>
         <source>Remove #END tag</source>
         <oldsource>Remove #END tag.</oldsource>
         <translation>Enlever le champ #END</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="53"/>
+        <location filename="QUCleanUpTask.cpp" line="44"/>
+        <source>Write song info to ID3 of the audio file. This will overwrite existing info!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="100"/>
+        <source>#ARTIST written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="105"/>
+        <source>#TITLE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="110"/>
+        <source>#GENRE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="115"/>
+        <source>#YEAR written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="120"/>
+        <source>#COMMENT written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="128"/>
+        <source>#LANGUAGE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="136"/>
+        <source>#BPM written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="173"/>
+        <source>Unsychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="263"/>
+        <source>Sychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="297"/>
+        <source>Cover image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="299"/>
+        <source>Song has no cover image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="336"/>
+        <source>Background image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="338"/>
+        <source>Song has no background image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="343"/>
+        <source>Cannot write song infos to ID3 tags. The audio file type is not yet supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="354"/>
         <source>Audio files</source>
         <translation>Fichiers audio</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="54"/>
+        <location filename="QUCleanUpTask.cpp" line="355"/>
         <source>Picture files</source>
         <translation>Fichiers image</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="55"/>
+        <location filename="QUCleanUpTask.cpp" line="356"/>
         <source>Video files</source>
         <translation>Fichiers vidéo</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="56"/>
+        <location filename="QUCleanUpTask.cpp" line="357"/>
         <source>Pattern:</source>
         <translation>Format:</translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="360"/>
+        <source>Write #ARTIST to ID3 artist tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="361"/>
+        <source>Write #TITLE to ID3 title tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="362"/>
+        <source>Write #GENRE to ID3 genre tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="363"/>
+        <source>Write #YEAR to ID3 year tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="364"/>
+        <source>Write #COMMENT to ID3 comment tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="365"/>
+        <source>Write #LANGUAGE to ID3 language tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="366"/>
+        <source>Write #BPM to ID3 BPM tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="367"/>
+        <source>Write song lyrics to ID3 unsychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="368"/>
+        <source>Write song lyrics to ID3 sychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="369"/>
+        <source>Write #COVER artwork to ID3 (FrontCover) artwork tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="370"/>
+        <source>Write #BACKGROUD artwork to ID3 (Artist) artwork tag</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/plugins/cleanup/cleanup.pl.ts
+++ b/src/plugins/cleanup/cleanup.pl.ts
@@ -4,50 +4,180 @@
 <context>
     <name>QUCleanUpTask</name>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="13"/>
+        <location filename="QUCleanUpTask.cpp" line="28"/>
         <source>Delete unused files</source>
         <translation>Usuń nieużywane pliki</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="14"/>
+        <location filename="QUCleanUpTask.cpp" line="29"/>
         <source>Every file which is not used by UltraStar will be deleted.&lt;br&gt;&lt;br&gt;&lt;b&gt;This cannot be undone!&lt;/b&gt;</source>
         <translation>Wszystkie pliki które nie są używane przez UltraStar&apos;a zostaną usunięte.&lt;br&gt;&lt;br&gt;&lt;b&gt;Tej operacji nie da się cofnąć!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="18"/>
+        <location filename="QUCleanUpTask.cpp" line="33"/>
         <source>Clear invalid file-related tags</source>
         <translation>Wyczyść błędnie wypełnione etykiety odwołujące się do plików</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="19"/>
+        <location filename="QUCleanUpTask.cpp" line="34"/>
         <source>Removes the value of invalid file-related tags so that they will not be saved into the song text file.&lt;br&gt;&lt;br&gt;This includes &lt;b&gt;#VIDEOGAP&lt;/b&gt; for invalid video files as well as &lt;b&gt;#START&lt;/b&gt; and &lt;b&gt;#END&lt;/b&gt; for invalid audio files.</source>
         <translation>Usuwa zawartość etykiet które odwołują się do nieistniejących fizycznie plików.&lt;br&gt;&lt;br&gt; Dotyczy to także etykiet &lt;b&gt;#VIDEOGAP&lt;/b&gt; dla nieprawidłowych lub nieistniejących plików teledysków oraz &lt;b&gt;#START&lt;/b&gt; i &lt;b&gt;#END&lt;/b&gt; dla nieprawidłowych lub nieistniejących plików z muzyką.</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="25"/>
+        <location filename="QUCleanUpTask.cpp" line="40"/>
         <source>Remove #END tag</source>
         <oldsource>Remove #END tag.</oldsource>
         <translation>Usuwa etykietę #END</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="53"/>
+        <location filename="QUCleanUpTask.cpp" line="44"/>
+        <source>Write song info to ID3 of the audio file. This will overwrite existing info!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="100"/>
+        <source>#ARTIST written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="105"/>
+        <source>#TITLE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="110"/>
+        <source>#GENRE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="115"/>
+        <source>#YEAR written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="120"/>
+        <source>#COMMENT written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="128"/>
+        <source>#LANGUAGE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="136"/>
+        <source>#BPM written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="173"/>
+        <source>Unsychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="263"/>
+        <source>Sychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="297"/>
+        <source>Cover image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="299"/>
+        <source>Song has no cover image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="336"/>
+        <source>Background image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="338"/>
+        <source>Song has no background image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="343"/>
+        <source>Cannot write song infos to ID3 tags. The audio file type is not yet supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="354"/>
         <source>Audio files</source>
         <translation>Pliki audio</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="54"/>
+        <location filename="QUCleanUpTask.cpp" line="355"/>
         <source>Picture files</source>
         <translation>Pliki graficzne</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="55"/>
+        <location filename="QUCleanUpTask.cpp" line="356"/>
         <source>Video files</source>
         <translation>Pliki video</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="56"/>
+        <location filename="QUCleanUpTask.cpp" line="357"/>
         <source>Pattern:</source>
         <translation>Wzór:</translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="360"/>
+        <source>Write #ARTIST to ID3 artist tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="361"/>
+        <source>Write #TITLE to ID3 title tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="362"/>
+        <source>Write #GENRE to ID3 genre tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="363"/>
+        <source>Write #YEAR to ID3 year tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="364"/>
+        <source>Write #COMMENT to ID3 comment tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="365"/>
+        <source>Write #LANGUAGE to ID3 language tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="366"/>
+        <source>Write #BPM to ID3 BPM tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="367"/>
+        <source>Write song lyrics to ID3 unsychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="368"/>
+        <source>Write song lyrics to ID3 sychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="369"/>
+        <source>Write #COVER artwork to ID3 (FrontCover) artwork tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="370"/>
+        <source>Write #BACKGROUD artwork to ID3 (Artist) artwork tag</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/plugins/cleanup/cleanup.pt.ts
+++ b/src/plugins/cleanup/cleanup.pt.ts
@@ -4,50 +4,180 @@
 <context>
     <name>QUCleanUpTask</name>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="13"/>
+        <location filename="QUCleanUpTask.cpp" line="28"/>
         <source>Delete unused files</source>
         <translation>Eliminar ficheiros não utilizados</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="14"/>
+        <location filename="QUCleanUpTask.cpp" line="29"/>
         <source>Every file which is not used by UltraStar will be deleted.&lt;br&gt;&lt;br&gt;&lt;b&gt;This cannot be undone!&lt;/b&gt;</source>
         <translation>Todos os ficheiros que não são usados pelo UltraStar serão eliminados.&lt;br&gt;&lt;br&gt;&lt;b&gt;A acção não pode ser desfeita!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="18"/>
+        <location filename="QUCleanUpTask.cpp" line="33"/>
         <source>Clear invalid file-related tags</source>
         <translation>Remover etiquetas inválidas do ficheiro</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="19"/>
+        <location filename="QUCleanUpTask.cpp" line="34"/>
         <source>Removes the value of invalid file-related tags so that they will not be saved into the song text file.&lt;br&gt;&lt;br&gt;This includes &lt;b&gt;#VIDEOGAP&lt;/b&gt; for invalid video files as well as &lt;b&gt;#START&lt;/b&gt; and &lt;b&gt;#END&lt;/b&gt; for invalid audio files.</source>
         <translation>Remover o valor de ficheiro inválido, relacionado com as etiquetas, de forma  a que eles não serão guardados no ficheiro de texto da canção.&lt;br&gt;&lt;br&gt;Isto inclui &lt;b&gt; # VIDEOGAP&lt;/b&gt; para ficheiros de vídeo inválidos, bem como &lt;b&gt;#START&lt;/b&gt; e &lt;b&gt;#END&lt;/b&gt; para ficheiros inválidos de áudio.</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="25"/>
+        <location filename="QUCleanUpTask.cpp" line="40"/>
         <source>Remove #END tag</source>
         <oldsource>Remove #END tag.</oldsource>
         <translation>Remover etiqueta #END</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="53"/>
+        <location filename="QUCleanUpTask.cpp" line="44"/>
+        <source>Write song info to ID3 of the audio file. This will overwrite existing info!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="100"/>
+        <source>#ARTIST written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="105"/>
+        <source>#TITLE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="110"/>
+        <source>#GENRE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="115"/>
+        <source>#YEAR written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="120"/>
+        <source>#COMMENT written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="128"/>
+        <source>#LANGUAGE written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="136"/>
+        <source>#BPM written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="173"/>
+        <source>Unsychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="263"/>
+        <source>Sychronized lyrics written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="297"/>
+        <source>Cover image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="299"/>
+        <source>Song has no cover image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="336"/>
+        <source>Background image written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="338"/>
+        <source>Song has no background image to be written to ID3 tag of song file: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="343"/>
+        <source>Cannot write song infos to ID3 tags. The audio file type is not yet supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="354"/>
         <source>Audio files</source>
         <translation>Ficheiros de Audio</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="54"/>
+        <location filename="QUCleanUpTask.cpp" line="355"/>
         <source>Picture files</source>
         <translation>Ficheiros de Imagem</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="55"/>
+        <location filename="QUCleanUpTask.cpp" line="356"/>
         <source>Video files</source>
         <translation>Ficheiros de Video</translation>
     </message>
     <message>
-        <location filename="QUCleanUpTask.cpp" line="56"/>
+        <location filename="QUCleanUpTask.cpp" line="357"/>
         <source>Pattern:</source>
         <translation>Padrão:</translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="360"/>
+        <source>Write #ARTIST to ID3 artist tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="361"/>
+        <source>Write #TITLE to ID3 title tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="362"/>
+        <source>Write #GENRE to ID3 genre tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="363"/>
+        <source>Write #YEAR to ID3 year tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="364"/>
+        <source>Write #COMMENT to ID3 comment tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="365"/>
+        <source>Write #LANGUAGE to ID3 language tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="366"/>
+        <source>Write #BPM to ID3 BPM tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="367"/>
+        <source>Write song lyrics to ID3 unsychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="368"/>
+        <source>Write song lyrics to ID3 sychronized lyrics tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="369"/>
+        <source>Write #COVER artwork to ID3 (FrontCover) artwork tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUCleanUpTask.cpp" line="370"/>
+        <source>Write #BACKGROUD artwork to ID3 (Artist) artwork tag</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/plugins/lyric/lyric.de.ts
+++ b/src/plugins/lyric/lyric.de.ts
@@ -45,8 +45,9 @@
     </message>
     <message>
         <location filename="QULyricTask.cpp" line="36"/>
-        <source>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</source>
-        <translation>Ersetzt falsch verwendete Apostrophsymbole `, ´, ’ durch den ASCII Apostroph &apos;</translation>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <oldsource>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</oldsource>
+        <translation type="unfinished">Ersetzt falsch verwendete Apostrophsymbole `, ´, ’ durch den ASCII Apostroph &apos;</translation>
     </message>
     <message>
         <location filename="QULyricTask.cpp" line="40"/>
@@ -115,48 +116,48 @@
         <translation>Start:</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="437"/>
+        <location filename="QULyricTask.cpp" line="482"/>
         <source>%1 wrong apostrophe symbols replaced successfully for &quot;%2 - %3&quot;.</source>
         <translation>%1 falsche Apostrophsymbole erfolgreich ersetzt: &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="538"/>
         <source>BPM changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>BPM geändert von %1 nach %2 für &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="511"/>
+        <location filename="QULyricTask.cpp" line="556"/>
         <source>Skipping medley search: medley tags already set for &quot;%1 - %2&quot;.</source>
         <translation>Überspringe Suche nach Medley-Abschnitt: Medley-Tags sind schon vorhanden für &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="516"/>
+        <location filename="QULyricTask.cpp" line="561"/>
         <source>Skipping medley search: medley tags not supported for duet &quot;%1 - %2&quot;.</source>
         <translation>Überspringe Suche nach Medley-Abschnitt: Medley-Tags werden für Duette nicht unterstützt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="521"/>
+        <location filename="QULyricTask.cpp" line="566"/>
         <source>Skipping medley search: relative format not supported for &quot;%1 - %2&quot;.</source>
         <translation>Überspringe Suche nach Medley-Abschnitt: Medley-Tags werden fürr relative Songs nicht unterstützt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="526"/>
+        <location filename="QULyricTask.cpp" line="571"/>
         <source>Skipping medley search: search disabled by CALCMEDLEY tag for song &quot;%1 - %2&quot;.</source>
         <translation>Überspringe Suche nach Medley-Abschnitt: Suche deaktiviert per CALCMEDLEY:OFF für &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="568"/>
+        <location filename="QULyricTask.cpp" line="613"/>
         <source>No medley candidates found for song &quot;%1 - %2&quot;</source>
         <oldsource>No medley candiates found for song &quot;%1 - %2&quot;</oldsource>
         <translation>Keine Kandidaten für Medley-Abschnitte gefunden für &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="619"/>
+        <location filename="QULyricTask.cpp" line="664"/>
         <source>Medley with a duration of %1 seconds set for &quot;%2 - %3&quot;.</source>
         <translation>Medley mit einer Länge von %1 Sekunden gesetzt für &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="627"/>
+        <location filename="QULyricTask.cpp" line="672"/>
         <source>No suitable medley section found for &quot;%1 - %2&quot;.</source>
         <translation>Keinen geeigneten Medley-Abschnitt gefunden für &quot;%1 - %2&quot;.</translation>
     </message>
@@ -168,8 +169,8 @@
     <message>
         <location filename="QULyricTask.cpp" line="153"/>
         <location filename="QULyricTask.cpp" line="307"/>
-        <location filename="QULyricTask.cpp" line="448"/>
-        <location filename="QULyricTask.cpp" line="506"/>
+        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="551"/>
         <source>Invalid lyrics in file &quot;%1&quot;</source>
         <translation>Ungültige Lyrics in Datei: &quot;%1&quot;</translation>
     </message>
@@ -181,13 +182,13 @@
     <message>
         <location filename="QULyricTask.cpp" line="233"/>
         <location filename="QULyricTask.cpp" line="367"/>
-        <location filename="QULyricTask.cpp" line="407"/>
-        <location filename="QULyricTask.cpp" line="638"/>
-        <location filename="QULyricTask.cpp" line="660"/>
-        <location filename="QULyricTask.cpp" line="707"/>
-        <location filename="QULyricTask.cpp" line="731"/>
-        <location filename="QULyricTask.cpp" line="757"/>
-        <location filename="QULyricTask.cpp" line="805"/>
+        <location filename="QULyricTask.cpp" line="452"/>
+        <location filename="QULyricTask.cpp" line="683"/>
+        <location filename="QULyricTask.cpp" line="705"/>
+        <location filename="QULyricTask.cpp" line="752"/>
+        <location filename="QULyricTask.cpp" line="776"/>
+        <location filename="QULyricTask.cpp" line="802"/>
+        <location filename="QULyricTask.cpp" line="850"/>
         <source>Invalid lyrics: %1 - %2</source>
         <translation>Ungültige Lyrics: %1 - %2</translation>
     </message>
@@ -237,7 +238,7 @@
         <translation>%1 von %2 überlappende Noten wurden korrigiert für &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="399"/>
+        <location filename="QULyricTask.cpp" line="402"/>
         <source>Spaces were fixed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Leerzeichen wurden erfolgreich korrigiert: &quot;%1 - %2&quot;.</translation>
     </message>
@@ -246,32 +247,32 @@
         <translation type="obsolete">#BPM geändert von %1 auf %2 für &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="650"/>
+        <location filename="QULyricTask.cpp" line="695"/>
         <source>Line capitalization fixed for &quot;%1 - %2&quot;.</source>
         <translation>Großschreibung am Zeilenanfang korrigiert für &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="694"/>
+        <location filename="QULyricTask.cpp" line="739"/>
         <source>Mean note pitch changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>Tonhöhenmittelwert geändert von %1 auf %2 für &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="726"/>
+        <location filename="QULyricTask.cpp" line="771"/>
         <source>Empty syllables were removed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Leere Silben wurden erfolgreich entfernt: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="745"/>
+        <location filename="QULyricTask.cpp" line="790"/>
         <source>Syllable placeholders were converted successfully from &apos;%3&apos; to &apos;%4&apos; for &quot;%1 - %2&quot;.</source>
         <translation>Platzhalter für Silben wurden erfolgreich konvertiert von &apos;%3&apos; nach &apos;%4&apos; für &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="795"/>
+        <location filename="QULyricTask.cpp" line="840"/>
         <source>Relative timestamps converted successfully to absolute timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Relative Zeitstempel wurden erfolgreich in absolute Werte konvertiert: &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="836"/>
+        <location filename="QULyricTask.cpp" line="881"/>
         <source>Absolute timestamps converted successfully to relative timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Absolute Zeitstempel wurden erfolgreich in relative Werte konvertiert: &quot;%1 - %2&quot;.</translation>
     </message>

--- a/src/plugins/lyric/lyric.es.ts
+++ b/src/plugins/lyric/lyric.es.ts
@@ -45,7 +45,8 @@
     </message>
     <message>
         <location filename="QULyricTask.cpp" line="36"/>
-        <source>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</source>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <oldsource>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -119,48 +120,48 @@
         <translation>Inicio:</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="437"/>
+        <location filename="QULyricTask.cpp" line="482"/>
         <source>%1 wrong apostrophe symbols replaced successfully for &quot;%2 - %3&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="538"/>
         <source>BPM changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>BPM cambió de %1 a %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="511"/>
+        <location filename="QULyricTask.cpp" line="556"/>
         <source>Skipping medley search: medley tags already set for &quot;%1 - %2&quot;.</source>
         <translation>Omision de la búsqueda del medley: las etiquetas de medley ya están para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="516"/>
+        <location filename="QULyricTask.cpp" line="561"/>
         <source>Skipping medley search: medley tags not supported for duet &quot;%1 - %2&quot;.</source>
         <translation>Omisión de la búsqueda del medley: las etiquetas de medley no están soportadas para el dueto &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="521"/>
+        <location filename="QULyricTask.cpp" line="566"/>
         <source>Skipping medley search: relative format not supported for &quot;%1 - %2&quot;.</source>
         <translation>Omisión de la búsqueda del medley: formato relativo no soportado para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="526"/>
+        <location filename="QULyricTask.cpp" line="571"/>
         <source>Skipping medley search: search disabled by CALCMEDLEY tag for song &quot;%1 - %2&quot;.</source>
         <translation>Omisión de la búsqueda del medley: búsqueda desactivada por la etiqueta CALCMEDLEY en la canción &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="568"/>
+        <location filename="QULyricTask.cpp" line="613"/>
         <source>No medley candidates found for song &quot;%1 - %2&quot;</source>
         <oldsource>No medley candiates found for song &quot;%1 - %2&quot;</oldsource>
         <translation>No se encontraron candidatos para medley en la canción &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="619"/>
+        <location filename="QULyricTask.cpp" line="664"/>
         <source>Medley with a duration of %1 seconds set for &quot;%2 - %3&quot;.</source>
         <translation>Se estableció un medley de duración %1 segundos para &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="627"/>
+        <location filename="QULyricTask.cpp" line="672"/>
         <source>No suitable medley section found for &quot;%1 - %2&quot;.</source>
         <translation>No se encontró ninguna seccion apropiada para el medley de &quot;%1 - %2&quot;.</translation>
     </message>
@@ -172,8 +173,8 @@
     <message>
         <location filename="QULyricTask.cpp" line="153"/>
         <location filename="QULyricTask.cpp" line="307"/>
-        <location filename="QULyricTask.cpp" line="448"/>
-        <location filename="QULyricTask.cpp" line="506"/>
+        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="551"/>
         <source>Invalid lyrics in file &quot;%1&quot;</source>
         <translation>Letra inválida en el archivo &quot;%1&quot;</translation>
     </message>
@@ -185,13 +186,13 @@
     <message>
         <location filename="QULyricTask.cpp" line="233"/>
         <location filename="QULyricTask.cpp" line="367"/>
-        <location filename="QULyricTask.cpp" line="407"/>
-        <location filename="QULyricTask.cpp" line="638"/>
-        <location filename="QULyricTask.cpp" line="660"/>
-        <location filename="QULyricTask.cpp" line="707"/>
-        <location filename="QULyricTask.cpp" line="731"/>
-        <location filename="QULyricTask.cpp" line="757"/>
-        <location filename="QULyricTask.cpp" line="805"/>
+        <location filename="QULyricTask.cpp" line="452"/>
+        <location filename="QULyricTask.cpp" line="683"/>
+        <location filename="QULyricTask.cpp" line="705"/>
+        <location filename="QULyricTask.cpp" line="752"/>
+        <location filename="QULyricTask.cpp" line="776"/>
+        <location filename="QULyricTask.cpp" line="802"/>
+        <location filename="QULyricTask.cpp" line="850"/>
         <source>Invalid lyrics: %1 - %2</source>
         <translation>Letra inválida: %1 - %2</translation>
     </message>
@@ -241,7 +242,7 @@
         <translation>%1 de %2 notas traslapadas fuero corregidas con éxito para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="399"/>
+        <location filename="QULyricTask.cpp" line="402"/>
         <source>Spaces were fixed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Los espacios fueron corregidos exitosamente para &quot;%1 - %2&quot;.</translation>
     </message>
@@ -250,32 +251,32 @@
         <translation type="obsolete">El #BPM cambió de %1 a %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="650"/>
+        <location filename="QULyricTask.cpp" line="695"/>
         <source>Line capitalization fixed for &quot;%1 - %2&quot;.</source>
         <translation>Mayúsculas de línea arregladas para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="694"/>
+        <location filename="QULyricTask.cpp" line="739"/>
         <source>Mean note pitch changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>Media de tonos cambió de %1 a %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="726"/>
+        <location filename="QULyricTask.cpp" line="771"/>
         <source>Empty syllables were removed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Se eliminaron sílabas vacías exitosamente para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="745"/>
+        <location filename="QULyricTask.cpp" line="790"/>
         <source>Syllable placeholders were converted successfully from &apos;%3&apos; to &apos;%4&apos; for &quot;%1 - %2&quot;.</source>
         <translation>Marcadores de posición de sílabas fueron convertidos exitosamente de &apos;%3&apos; a &apos;%4&apos; para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="795"/>
+        <location filename="QULyricTask.cpp" line="840"/>
         <source>Relative timestamps converted successfully to absolute timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Marcadores de tiempo fueron convertidos exitosamente de relativos a absolutos para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="836"/>
+        <location filename="QULyricTask.cpp" line="881"/>
         <source>Absolute timestamps converted successfully to relative timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Marcadores de tiempo fueron convertidos exitosamente de absolutos a relativos para &quot;%1 - %2&quot;.</translation>
     </message>

--- a/src/plugins/lyric/lyric.fr.ts
+++ b/src/plugins/lyric/lyric.fr.ts
@@ -45,7 +45,8 @@
     </message>
     <message>
         <location filename="QULyricTask.cpp" line="36"/>
-        <source>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</source>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <oldsource>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -120,48 +121,48 @@
         <translation>Départ:</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="437"/>
+        <location filename="QULyricTask.cpp" line="482"/>
         <source>%1 wrong apostrophe symbols replaced successfully for &quot;%2 - %3&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="538"/>
         <source>BPM changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>BPM changé de %1 en %2 pour &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="511"/>
+        <location filename="QULyricTask.cpp" line="556"/>
         <source>Skipping medley search: medley tags already set for &quot;%1 - %2&quot;.</source>
         <translation>Saut de la recherche de medley: le champ medley est déjà fixé pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="516"/>
+        <location filename="QULyricTask.cpp" line="561"/>
         <source>Skipping medley search: medley tags not supported for duet &quot;%1 - %2&quot;.</source>
         <translation>Saut de la recherche de medley: le champ medley n&apos;est pas supporté par le duo &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="521"/>
+        <location filename="QULyricTask.cpp" line="566"/>
         <source>Skipping medley search: relative format not supported for &quot;%1 - %2&quot;.</source>
         <translation>Saut de la recherche de medley:le format relatif n&apos;est pas supporté pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="526"/>
+        <location filename="QULyricTask.cpp" line="571"/>
         <source>Skipping medley search: search disabled by CALCMEDLEY tag for song &quot;%1 - %2&quot;.</source>
         <translation>Saut de la recherche de medley: recherche désactivée par le champ CALCMEDLEY pour la chanson &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="568"/>
+        <location filename="QULyricTask.cpp" line="613"/>
         <source>No medley candidates found for song &quot;%1 - %2&quot;</source>
         <oldsource>No medley candiates found for song &quot;%1 - %2&quot;</oldsource>
         <translation>Pas de candidat trouvé pour un medley pour la chanson &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="619"/>
+        <location filename="QULyricTask.cpp" line="664"/>
         <source>Medley with a duration of %1 seconds set for &quot;%2 - %3&quot;.</source>
         <translation>Medley d&apos;une durée de %1 secondes fixé pour &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="627"/>
+        <location filename="QULyricTask.cpp" line="672"/>
         <source>No suitable medley section found for &quot;%1 - %2&quot;.</source>
         <translation>Pas de zone utilisable pour un medley pour la chanson &quot;%1 - %2&quot;.</translation>
     </message>
@@ -173,8 +174,8 @@
     <message>
         <location filename="QULyricTask.cpp" line="153"/>
         <location filename="QULyricTask.cpp" line="307"/>
-        <location filename="QULyricTask.cpp" line="448"/>
-        <location filename="QULyricTask.cpp" line="506"/>
+        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="551"/>
         <source>Invalid lyrics in file &quot;%1&quot;</source>
         <translation>Paroles invalides dans le fichier &quot;%1&quot;</translation>
     </message>
@@ -186,13 +187,13 @@
     <message>
         <location filename="QULyricTask.cpp" line="233"/>
         <location filename="QULyricTask.cpp" line="367"/>
-        <location filename="QULyricTask.cpp" line="407"/>
-        <location filename="QULyricTask.cpp" line="638"/>
-        <location filename="QULyricTask.cpp" line="660"/>
-        <location filename="QULyricTask.cpp" line="707"/>
-        <location filename="QULyricTask.cpp" line="731"/>
-        <location filename="QULyricTask.cpp" line="757"/>
-        <location filename="QULyricTask.cpp" line="805"/>
+        <location filename="QULyricTask.cpp" line="452"/>
+        <location filename="QULyricTask.cpp" line="683"/>
+        <location filename="QULyricTask.cpp" line="705"/>
+        <location filename="QULyricTask.cpp" line="752"/>
+        <location filename="QULyricTask.cpp" line="776"/>
+        <location filename="QULyricTask.cpp" line="802"/>
+        <location filename="QULyricTask.cpp" line="850"/>
         <source>Invalid lyrics: %1 - %2</source>
         <translation>Paroles invalides: %1 - %2</translation>
     </message>
@@ -242,7 +243,7 @@
         <translation>%1 sur %2 notes se chevauchant ont été corrigées avec succès pour &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="399"/>
+        <location filename="QULyricTask.cpp" line="402"/>
         <source>Spaces were fixed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Les espaces ont été corrigés avec succès pour &quot;%1 - %2&quot;.</translation>
     </message>
@@ -251,32 +252,32 @@
         <translation type="obsolete">#BPM changé de %1 en %2 pour &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="650"/>
+        <location filename="QULyricTask.cpp" line="695"/>
         <source>Line capitalization fixed for &quot;%1 - %2&quot;.</source>
         <translation>Mise en capitale des lignes effectué pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="694"/>
+        <location filename="QULyricTask.cpp" line="739"/>
         <source>Mean note pitch changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>Moyenne du pitch des notes changé de %1 en %2 pour &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="726"/>
+        <location filename="QULyricTask.cpp" line="771"/>
         <source>Empty syllables were removed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Les syllabes vides ont été enlevées avec succès pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="745"/>
+        <location filename="QULyricTask.cpp" line="790"/>
         <source>Syllable placeholders were converted successfully from &apos;%3&apos; to &apos;%4&apos; for &quot;%1 - %2&quot;.</source>
         <translation>Les syllabes longues ont été converties avec succès de &apos;%3&apos; en &apos;%4&apos; pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="795"/>
+        <location filename="QULyricTask.cpp" line="840"/>
         <source>Relative timestamps converted successfully to absolute timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Les marqueurs de temps relatifs ont été convertis avec succès en marqueurs absolus pour &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="836"/>
+        <location filename="QULyricTask.cpp" line="881"/>
         <source>Absolute timestamps converted successfully to relative timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Les marqueurs de temps absolus ont été convertis avec succès en marqueurs relatifs pour &quot;%1 - %2&quot;.</translation>
     </message>

--- a/src/plugins/lyric/lyric.pl.ts
+++ b/src/plugins/lyric/lyric.pl.ts
@@ -45,7 +45,8 @@
     </message>
     <message>
         <location filename="QULyricTask.cpp" line="36"/>
-        <source>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</source>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <oldsource>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -115,48 +116,48 @@
         <translation>Start:</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="437"/>
+        <location filename="QULyricTask.cpp" line="482"/>
         <source>%1 wrong apostrophe symbols replaced successfully for &quot;%2 - %3&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="538"/>
         <source>BPM changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="511"/>
+        <location filename="QULyricTask.cpp" line="556"/>
         <source>Skipping medley search: medley tags already set for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="516"/>
+        <location filename="QULyricTask.cpp" line="561"/>
         <source>Skipping medley search: medley tags not supported for duet &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="521"/>
+        <location filename="QULyricTask.cpp" line="566"/>
         <source>Skipping medley search: relative format not supported for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="526"/>
+        <location filename="QULyricTask.cpp" line="571"/>
         <source>Skipping medley search: search disabled by CALCMEDLEY tag for song &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="568"/>
+        <location filename="QULyricTask.cpp" line="613"/>
         <source>No medley candidates found for song &quot;%1 - %2&quot;</source>
         <oldsource>No medley candiates found for song &quot;%1 - %2&quot;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="619"/>
+        <location filename="QULyricTask.cpp" line="664"/>
         <source>Medley with a duration of %1 seconds set for &quot;%2 - %3&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="627"/>
+        <location filename="QULyricTask.cpp" line="672"/>
         <source>No suitable medley section found for &quot;%1 - %2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -168,8 +169,8 @@
     <message>
         <location filename="QULyricTask.cpp" line="153"/>
         <location filename="QULyricTask.cpp" line="307"/>
-        <location filename="QULyricTask.cpp" line="448"/>
-        <location filename="QULyricTask.cpp" line="506"/>
+        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="551"/>
         <source>Invalid lyrics in file &quot;%1&quot;</source>
         <translation>Złe słowa piosenki w pliku &quot;%1&quot;</translation>
     </message>
@@ -181,13 +182,13 @@
     <message>
         <location filename="QULyricTask.cpp" line="233"/>
         <location filename="QULyricTask.cpp" line="367"/>
-        <location filename="QULyricTask.cpp" line="407"/>
-        <location filename="QULyricTask.cpp" line="638"/>
-        <location filename="QULyricTask.cpp" line="660"/>
-        <location filename="QULyricTask.cpp" line="707"/>
-        <location filename="QULyricTask.cpp" line="731"/>
-        <location filename="QULyricTask.cpp" line="757"/>
-        <location filename="QULyricTask.cpp" line="805"/>
+        <location filename="QULyricTask.cpp" line="452"/>
+        <location filename="QULyricTask.cpp" line="683"/>
+        <location filename="QULyricTask.cpp" line="705"/>
+        <location filename="QULyricTask.cpp" line="752"/>
+        <location filename="QULyricTask.cpp" line="776"/>
+        <location filename="QULyricTask.cpp" line="802"/>
+        <location filename="QULyricTask.cpp" line="850"/>
         <source>Invalid lyrics: %1 - %2</source>
         <translation>Złe słowa piosenki: %1 - %2</translation>
     </message>
@@ -237,7 +238,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="399"/>
+        <location filename="QULyricTask.cpp" line="402"/>
         <source>Spaces were fixed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Odstępy zostały pomyślnie zmienione dla %1 - %2&quot;.</translation>
     </message>
@@ -246,32 +247,32 @@
         <translation type="obsolete">#BPM zmieniony z %1 do %2 dla &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="650"/>
+        <location filename="QULyricTask.cpp" line="695"/>
         <source>Line capitalization fixed for &quot;%1 - %2&quot;.</source>
         <translation>Linie &quot;Wielką Literą&quot; zmienione dla &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="694"/>
+        <location filename="QULyricTask.cpp" line="739"/>
         <source>Mean note pitch changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>Średnia wysokość nut zmieniona z %1 do %2 dla &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="726"/>
+        <location filename="QULyricTask.cpp" line="771"/>
         <source>Empty syllables were removed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Puste sylaby zostały pomyślnie usunięte dla &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="745"/>
+        <location filename="QULyricTask.cpp" line="790"/>
         <source>Syllable placeholders were converted successfully from &apos;%3&apos; to &apos;%4&apos; for &quot;%1 - %2&quot;.</source>
         <translation>Sylaby zostały pomyślnie zmienione z &apos;%3&apos; do &apos;%4&apos; dla &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="795"/>
+        <location filename="QULyricTask.cpp" line="840"/>
         <source>Relative timestamps converted successfully to absolute timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Względne nuty zostały pomyślnie zmienionie na bezwzględne dla &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="836"/>
+        <location filename="QULyricTask.cpp" line="881"/>
         <source>Absolute timestamps converted successfully to relative timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Bezwzględne nuty zostały pomyślnie zmienionie na względne dla &quot;%1 - %2&quot;.</translation>
     </message>

--- a/src/plugins/lyric/lyric.pt.ts
+++ b/src/plugins/lyric/lyric.pt.ts
@@ -45,7 +45,8 @@
     </message>
     <message>
         <location filename="QULyricTask.cpp" line="36"/>
-        <source>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</source>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <oldsource>Replaces wrongfully used apostrophe symbols `, ´, ’ by the ASCII apostrophe &apos;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -119,48 +120,48 @@
         <translation>Inicio:</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="437"/>
+        <location filename="QULyricTask.cpp" line="482"/>
         <source>%1 wrong apostrophe symbols replaced successfully for &quot;%2 - %3&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="538"/>
         <source>BPM changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>BPM alterado de %1 para %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="511"/>
+        <location filename="QULyricTask.cpp" line="556"/>
         <source>Skipping medley search: medley tags already set for &quot;%1 - %2&quot;.</source>
         <translation>Pesquisa etiqueta medley: medley já está definido para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="516"/>
+        <location filename="QULyricTask.cpp" line="561"/>
         <source>Skipping medley search: medley tags not supported for duet &quot;%1 - %2&quot;.</source>
         <translation>Pesquisa etiqueta medley: etiqueta medley não é suportada para o dueto &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="521"/>
+        <location filename="QULyricTask.cpp" line="566"/>
         <source>Skipping medley search: relative format not supported for &quot;%1 - %2&quot;.</source>
         <translation>Pesquisa etiqueta medley: tempo relativo não é suportado para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="526"/>
+        <location filename="QULyricTask.cpp" line="571"/>
         <source>Skipping medley search: search disabled by CALCMEDLEY tag for song &quot;%1 - %2&quot;.</source>
         <translation>Pesquisa etiqueta medley: pesquisa desabilitada por etiqueta #CALCMEDLEY para canção &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="568"/>
+        <location filename="QULyricTask.cpp" line="613"/>
         <source>No medley candidates found for song &quot;%1 - %2&quot;</source>
         <oldsource>No medley candiates found for song &quot;%1 - %2&quot;</oldsource>
         <translation>Medleynão encontrado para canção &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="619"/>
+        <location filename="QULyricTask.cpp" line="664"/>
         <source>Medley with a duration of %1 seconds set for &quot;%2 - %3&quot;.</source>
         <translation>Medley com duração de %1 segundos atribuída a &quot;%2 - %3&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="627"/>
+        <location filename="QULyricTask.cpp" line="672"/>
         <source>No suitable medley section found for &quot;%1 - %2&quot;.</source>
         <translation>Não foi encontrada nenhuma secção medley adequada para &quot;%1 - %2&quot;.</translation>
     </message>
@@ -171,8 +172,8 @@
     <message>
         <location filename="QULyricTask.cpp" line="153"/>
         <location filename="QULyricTask.cpp" line="307"/>
-        <location filename="QULyricTask.cpp" line="448"/>
-        <location filename="QULyricTask.cpp" line="506"/>
+        <location filename="QULyricTask.cpp" line="493"/>
+        <location filename="QULyricTask.cpp" line="551"/>
         <source>Invalid lyrics in file &quot;%1&quot;</source>
         <translation>Letra inválida no ficheiro &quot;%1&quot;</translation>
     </message>
@@ -194,13 +195,13 @@
     <message>
         <location filename="QULyricTask.cpp" line="233"/>
         <location filename="QULyricTask.cpp" line="367"/>
-        <location filename="QULyricTask.cpp" line="407"/>
-        <location filename="QULyricTask.cpp" line="638"/>
-        <location filename="QULyricTask.cpp" line="660"/>
-        <location filename="QULyricTask.cpp" line="707"/>
-        <location filename="QULyricTask.cpp" line="731"/>
-        <location filename="QULyricTask.cpp" line="757"/>
-        <location filename="QULyricTask.cpp" line="805"/>
+        <location filename="QULyricTask.cpp" line="452"/>
+        <location filename="QULyricTask.cpp" line="683"/>
+        <location filename="QULyricTask.cpp" line="705"/>
+        <location filename="QULyricTask.cpp" line="752"/>
+        <location filename="QULyricTask.cpp" line="776"/>
+        <location filename="QULyricTask.cpp" line="802"/>
+        <location filename="QULyricTask.cpp" line="850"/>
         <source>Invalid lyrics: %1 - %2</source>
         <translation>Letra inválida: %1 - %2</translation>
     </message>
@@ -240,7 +241,7 @@
         <translation>%1 de %2 notas sobrepostas foram corrigidas com sucesso para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="399"/>
+        <location filename="QULyricTask.cpp" line="402"/>
         <source>Spaces were fixed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Espaços corrigidos com sucesso para &quot;%1 - %2&quot;.</translation>
     </message>
@@ -249,32 +250,32 @@
         <translation type="obsolete">#BPM alterado de %1 para %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="650"/>
+        <location filename="QULyricTask.cpp" line="695"/>
         <source>Line capitalization fixed for &quot;%1 - %2&quot;.</source>
         <translation>Capitalização da linha corrigida para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="694"/>
+        <location filename="QULyricTask.cpp" line="739"/>
         <source>Mean note pitch changed from %1 to %2 for &quot;%3 - %4&quot;.</source>
         <translation>A média de tons passou de %1 para %2 para &quot;%3 - %4&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="726"/>
+        <location filename="QULyricTask.cpp" line="771"/>
         <source>Empty syllables were removed successfully for &quot;%1 - %2&quot;.</source>
         <translation>Sílabas vazias removidas com sucesso para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="745"/>
+        <location filename="QULyricTask.cpp" line="790"/>
         <source>Syllable placeholders were converted successfully from &apos;%3&apos; to &apos;%4&apos; for &quot;%1 - %2&quot;.</source>
         <translation>Sílaba de mudança de tom convertida com sucesso de &apos;%3&apos; a &apos;%4&apos; para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="795"/>
+        <location filename="QULyricTask.cpp" line="840"/>
         <source>Relative timestamps converted successfully to absolute timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Timestamp relativo convertido com sucesso para absoluto para &quot;%1 - %2&quot;.</translation>
     </message>
     <message>
-        <location filename="QULyricTask.cpp" line="836"/>
+        <location filename="QULyricTask.cpp" line="881"/>
         <source>Absolute timestamps converted successfully to relative timestamps for &quot;%1 - %2&quot;.</source>
         <translation>Timestamp absoluto convertido com sucesso para relativo para &quot;%1 - %2&quot;.</translation>
     </message>

--- a/src/plugins/preparatory/preparatory.de.ts
+++ b/src/plugins/preparatory/preparatory.de.ts
@@ -84,71 +84,182 @@
         <translation>Korrigiert die Großschreibung eines jeden Wortes des Interpreten, z.B. &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <source>Set #EDITION tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <source>Set #GENRE tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <source>Fix #LANGUAGE tag to contain English language names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <source>Fix apostrophes in song artist and title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <source>Add missing ’P1’ and ’P2’ in duets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>Pattern:</source>
         <translation>Muster:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
         <source>(cover)</source>
         <translation>(Cover)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>(background)</source>
         <translation>(Hintergrund)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>Buffer:</source>
         <translation>Puffer:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>seconds</source>
         <translation>Sekunden</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="105"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Capitalize English songs only</source>
         <translation>Korrigiere die Großschreibung nur von englischen Songs</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="106"/>
+        <location filename="QUPreparatoryTask.cpp" line="146"/>
         <source>Capitalize each word</source>
         <translation>Schreibe jeden Wortanfang groß</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="107"/>
-        <location filename="QUPreparatoryTask.cpp" line="110"/>
+        <location filename="QUPreparatoryTask.cpp" line="147"/>
+        <location filename="QUPreparatoryTask.cpp" line="150"/>
         <source>Capitalize first word only</source>
         <translation>Schreibe nur den ersten Wortanfang groß</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="149"/>
+        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <source>Edition:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <source>Genre:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="195"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>Großschreibung konnte nicht angepasst werden, da der Song nicht englisch ist: &quot;%1 - %2&quot;. Hinweis: Aufgabeneinstellung anpassen.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <source>#EDITION set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <source>#GENRE set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <source>Line: %1, Note: %2, Diff: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;</source>
-        <translation>Großschreibung konnte nicht angepasst werden, da der Titel fehlt: &quot;%1&quot;</translation>
+        <translation type="vanished">Großschreibung konnte nicht angepasst werden, da der Titel fehlt: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="222"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;</source>
-        <translation>Großschreibung angepasst für #TITLE für: &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">Großschreibung angepasst für #TITLE für: &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="235"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;</source>
-        <translation>Großschreibung konnte nicht angepasst werden, da der Interpret fehlt: &quot;%1&quot;</translation>
+        <translation type="vanished">Großschreibung konnte nicht angepasst werden, da der Interpret fehlt: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="250"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;</source>
-        <translation>Großschreibung angepasst für #ARTIST für: &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">Großschreibung angepasst für #ARTIST für: &quot;%1 - %2&quot;</translation>
     </message>
 </context>
 <context>

--- a/src/plugins/preparatory/preparatory.es.ts
+++ b/src/plugins/preparatory/preparatory.es.ts
@@ -80,71 +80,182 @@
         <translation>Utiliza mayúsculas en cada palabra del artista, ej.: &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <source>Set #EDITION tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <source>Set #GENRE tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <source>Fix #LANGUAGE tag to contain English language names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <source>Fix apostrophes in song artist and title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <source>Add missing ’P1’ and ’P2’ in duets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>Pattern:</source>
         <translation>Patron:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
         <source>(cover)</source>
         <translation>(carátula)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>(background)</source>
         <translation>(imagen de fondo)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>Buffer:</source>
         <translation>Buffer:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="105"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Capitalize English songs only</source>
         <translation>Utilizar mayúsculas solo en las canciones en inglés</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="106"/>
+        <location filename="QUPreparatoryTask.cpp" line="146"/>
         <source>Capitalize each word</source>
         <translation>Utilizar mayúsculas en cada palabra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="107"/>
-        <location filename="QUPreparatoryTask.cpp" line="110"/>
+        <location filename="QUPreparatoryTask.cpp" line="147"/>
+        <location filename="QUPreparatoryTask.cpp" line="150"/>
         <source>Capitalize first word only</source>
         <translation>Utilizar mayúsculas solo en la primera palabra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="149"/>
+        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <source>Edition:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <source>Genre:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="195"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>Uso de mayúsculas no corresponde por no ser una canción en inglés: &quot;%1 - %2&quot;. Intenta configurar la tarea.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <source>#EDITION set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <source>#GENRE set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <source>Line: %1, Note: %2, Diff: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;</source>
-        <translation>Uso de mayúsculas no corresponde por título vacío: &quot;%1&quot;</translation>
+        <translation type="vanished">Uso de mayúsculas no corresponde por título vacío: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="222"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;</source>
-        <translation>Uso de mayúsculas en #TITLE para &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">Uso de mayúsculas en #TITLE para &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="235"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;</source>
-        <translation>Uso de mayúsculas no corresponde por artista vacío: &quot;%1&quot;</translation>
+        <translation type="vanished">Uso de mayúsculas no corresponde por artista vacío: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="250"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;</source>
-        <translation>Uso de mayúsculas en #ARTIST para &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">Uso de mayúsculas en #ARTIST para &quot;%1 - %2&quot;</translation>
     </message>
 </context>
 <context>

--- a/src/plugins/preparatory/preparatory.fr.ts
+++ b/src/plugins/preparatory/preparatory.fr.ts
@@ -80,71 +80,182 @@
         <translation>Mettre des capitales à chaque mot du champ #ARTIST, par exemple &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <source>Set #EDITION tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <source>Set #GENRE tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <source>Fix #LANGUAGE tag to contain English language names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <source>Fix apostrophes in song artist and title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <source>Add missing ’P1’ and ’P2’ in duets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>Pattern:</source>
         <translation>Modèle:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
         <source>(cover)</source>
         <translation>(couverture)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>(background)</source>
         <translation>(fond d&apos;écran)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>Buffer:</source>
         <translation>Mémoire tampon:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>seconds</source>
         <translation>secondes</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="105"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Capitalize English songs only</source>
         <translation>Ne mettre des capitales que dans les chansons anglaises</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="106"/>
+        <location filename="QUPreparatoryTask.cpp" line="146"/>
         <source>Capitalize each word</source>
         <translation>Mettre des capitales à tous les mots</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="107"/>
-        <location filename="QUPreparatoryTask.cpp" line="110"/>
+        <location filename="QUPreparatoryTask.cpp" line="147"/>
+        <location filename="QUPreparatoryTask.cpp" line="150"/>
         <source>Capitalize first word only</source>
         <translation>Mettre des capitales qu&apos;aux premiers mots</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="149"/>
+        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <source>Edition:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <source>Genre:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="195"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>La correction des capitales n&apos;est pas applicable à &quot;%1 - %2&quot; car ce n&apos;est pas une chanson anglaise. Essayez de configurer la tâche.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <source>#EDITION set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <source>#GENRE set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <source>Line: %1, Note: %2, Diff: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;</source>
-        <translation>La correction des capitales n&apos;est pas applicable à &quot;%1&quot; car le titre est vide</translation>
+        <translation type="vanished">La correction des capitales n&apos;est pas applicable à &quot;%1&quot; car le titre est vide</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="222"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;</source>
-        <translation>La mise en capitale du champ #TITLE a été corrigée pour &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">La mise en capitale du champ #TITLE a été corrigée pour &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="235"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;</source>
-        <translation>La correction des capitales n&apos;est pas applicable à &quot;%1&quot; car le nom de l&apos;artiste est vide</translation>
+        <translation type="vanished">La correction des capitales n&apos;est pas applicable à &quot;%1&quot; car le nom de l&apos;artiste est vide</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="250"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;</source>
-        <translation>La mise en capitale du champ #ARTIST a été corrigée pour &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">La mise en capitale du champ #ARTIST a été corrigée pour &quot;%1 - %2&quot;</translation>
     </message>
 </context>
 <context>

--- a/src/plugins/preparatory/preparatory.pl.ts
+++ b/src/plugins/preparatory/preparatory.pl.ts
@@ -84,71 +84,182 @@
         <translation>&quot;Wielką Literą&quot; nazwa wykonawcy, np. &quot;sylwia grzeszczak&quot; -&gt; &quot;Sylwia Grzeszczak&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <source>Set #EDITION tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <source>Set #GENRE tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <source>Fix #LANGUAGE tag to contain English language names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <source>Fix apostrophes in song artist and title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <source>Add missing ’P1’ and ’P2’ in duets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>Pattern:</source>
         <translation>Wzór:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
         <source>(cover)</source>
         <translation>(okładka)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>(background)</source>
         <translation>(tło)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>Buffer:</source>
         <translation>Bufor:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>seconds</source>
         <translation>sekundy</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="105"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Capitalize English songs only</source>
         <translation>&quot;Wielką Literą&quot; tylko angielskie piosenki</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="106"/>
+        <location filename="QUPreparatoryTask.cpp" line="146"/>
         <source>Capitalize each word</source>
         <translation>&quot;Wielką Literą&quot; każde słowo</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="107"/>
-        <location filename="QUPreparatoryTask.cpp" line="110"/>
+        <location filename="QUPreparatoryTask.cpp" line="147"/>
+        <location filename="QUPreparatoryTask.cpp" line="150"/>
         <source>Capitalize first word only</source>
         <translation>&quot;Wielką Literą&quot; tylko pierwsze słowo</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="149"/>
+        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <source>Edition:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <source>Genre:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="195"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>&quot;Wielką Literą&quot; nie może być zastosowane do nieangielskich piosenek: &quot;%1 - %2&quot;. Spróbuj zmienić zadanie.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <source>#EDITION set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <source>#GENRE set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <source>Line: %1, Note: %2, Diff: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;</source>
-        <translation>&quot;Wielką Literą&quot; nie może być użyte dla pustego tytułu: &quot;%1&quot;</translation>
+        <translation type="vanished">&quot;Wielką Literą&quot; nie może być użyte dla pustego tytułu: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="222"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;</source>
-        <translation>&quot;Wielką Literą&quot; użyte dla #TITLE (tytuł) dla &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">&quot;Wielką Literą&quot; użyte dla #TITLE (tytuł) dla &quot;%1 - %2&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="235"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;</source>
-        <translation>&quot;Wielką Literą&quot; nie może być użyte dla pustego wykonawcy: &quot;%1&quot;</translation>
+        <translation type="vanished">&quot;Wielką Literą&quot; nie może być użyte dla pustego wykonawcy: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="250"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;</source>
-        <translation>&quot;Wielką Literą&quot; użyte dla #ARTIST (artysta) dla &quot;%1 - %2&quot;</translation>
+        <translation type="vanished">&quot;Wielką Literą&quot; użyte dla #ARTIST (artysta) dla &quot;%1 - %2&quot;</translation>
     </message>
 </context>
 <context>

--- a/src/plugins/preparatory/preparatory.pt.ts
+++ b/src/plugins/preparatory/preparatory.pt.ts
@@ -80,71 +80,182 @@
         <translation>Capitalizar cada palavra do artista, ex: &quot;michael jackson&quot; -&gt; &quot;Michael Jackson&quot;.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="53"/>
+        <source>Set #EDITION tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="54"/>
+        <source>Sets &lt;b&gt;#EDITION&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="58"/>
+        <source>Set #GENRE tag if it is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="59"/>
+        <source>Sets &lt;b&gt;#GENRE&lt;/b&gt; to a defined value if it is empty or not present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="63"/>
+        <source>Fix #LANGUAGE tag to contain English language names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="64"/>
+        <source>Sets &lt;b&gt;#LANGUAGE&lt;/b&gt; to contain English language names (e.g. Deutsch -&gt; German).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="68"/>
+        <source>Fix apostrophes in song artist and title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="69"/>
+        <source>Replaces wrongfully used apostrophe symbols `, ´, &apos; by the correct apostrophe ’</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="73"/>
+        <source>Add missing ’P1’ and ’P2’ in duets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="74"/>
+        <source>Detects if a song is a duet that is missing ’P1’ and ’P2’ tags and adds them</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>Pattern:</source>
         <translation>Padrão:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="94"/>
+        <location filename="QUPreparatoryTask.cpp" line="134"/>
         <source>(cover)</source>
         <translation>(capa)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="95"/>
+        <location filename="QUPreparatoryTask.cpp" line="135"/>
         <source>(background)</source>
         <translation>(fundo)</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>Buffer:</source>
         <translation>Buffer:</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="102"/>
+        <location filename="QUPreparatoryTask.cpp" line="142"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="105"/>
+        <location filename="QUPreparatoryTask.cpp" line="145"/>
         <source>Capitalize English songs only</source>
         <translation>Capitalizar apenas canções inglesas</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="106"/>
+        <location filename="QUPreparatoryTask.cpp" line="146"/>
         <source>Capitalize each word</source>
         <translation>Capitalizar cada palavra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="107"/>
-        <location filename="QUPreparatoryTask.cpp" line="110"/>
+        <location filename="QUPreparatoryTask.cpp" line="147"/>
+        <location filename="QUPreparatoryTask.cpp" line="150"/>
         <source>Capitalize first word only</source>
         <translation>Capitalizar apenas primeira palavra</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="149"/>
+        <location filename="QUPreparatoryTask.cpp" line="153"/>
+        <source>Edition:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="156"/>
+        <source>Genre:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="195"/>
         <source>Capitalization fix not applicable due to non-english song: &quot;%1 - %2&quot;. Try to configure the task.</source>
         <translation>Corrigir capitalização não aplicável, devido às canções não-inglesas: &quot;%1 -%2&quot;. Tente configurar a tarefa.</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="157"/>
+        <location filename="QUPreparatoryTask.cpp" line="203"/>
+        <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="268"/>
+        <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="281"/>
+        <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="296"/>
+        <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="305"/>
+        <source>#EDITION set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="315"/>
+        <source>#GENRE set to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="379"/>
+        <source>#LANGUAGE changed from &quot;%1&quot; to &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="395"/>
+        <source>Apostrophes fixed for &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="424"/>
+        <source>Line: %1, Note: %2, Diff: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="431"/>
+        <source>Potential duet with missing duet tags detected: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="QUPreparatoryTask.cpp" line="456"/>
+        <source>Not a potential duet: &quot;%1 - %2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Capitalization fix not applicable due to empty title: &quot;%1&quot;</source>
-        <translation>Corrigir capitalização não aplicável, devido a título vazio: &quot;%1&quot;</translation>
+        <translation type="vanished">Corrigir capitalização não aplicável, devido a título vazio: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="222"/>
         <source>Capitalization of #TITLE fixed for &quot;%1 - %2&quot;</source>
-        <translation>Capitalização de #TITLE corrigida para &quot;%1&apos;-&apos;%2&quot;</translation>
+        <translation type="vanished">Capitalização de #TITLE corrigida para &quot;%1&apos;-&apos;%2&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="235"/>
         <source>Capitalization fix not applicable due to empty artist: &quot;%1&quot;</source>
-        <translation>Corrigir capitalização não aplicável, devido a artista vazio: &quot;%1&quot;</translation>
+        <translation type="vanished">Corrigir capitalização não aplicável, devido a artista vazio: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="QUPreparatoryTask.cpp" line="250"/>
         <source>Capitalization of #ARTIST fixed for &quot;%1 - %2&quot;</source>
-        <translation>Capitalização de #ARTIST corrigida para &quot;%1&apos;-&apos;%2&quot;</translation>
+        <translation type="vanished">Capitalização de #ARTIST corrigida para &quot;%1&apos;-&apos;%2&quot;</translation>
     </message>
 </context>
 <context>

--- a/src/plugins/rename/rename.de.ts
+++ b/src/plugins/rename/rename.de.ts
@@ -294,76 +294,76 @@
         <translation>Bearbeite &quot;Umbenennen&quot;-Aufgabe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Beschreibung</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>&amp;ToolTip</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Icon</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Gruppe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Exclusive Aufgabe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Ziel</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>Das Ziel bestimmt die Stelle, welche umbenannt wird.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Schema</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Speichern unter...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>

--- a/src/plugins/rename/rename.es.ts
+++ b/src/plugins/rename/rename.es.ts
@@ -270,76 +270,76 @@
         <translation>Editar tarea de cambio de nombre</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Descripción</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Ícono</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Grupo</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Tarea exclusiva</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Objetivo</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>El objetivo especifica el objeto en el que el se hará el cambio de nombre.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Esquema</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>

--- a/src/plugins/rename/rename.fr.ts
+++ b/src/plugins/rename/rename.fr.ts
@@ -254,76 +254,76 @@
         <translation>Modifier la tâche de renommage</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Description</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>Info&amp;bulle</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Icone</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation>Coupe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Groupe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Tâche exclusive</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Cible</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>La cible désigne l&apos;objet sur lequel l&apos;opération de renommage va être éffectuée.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Schéma</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Sauvegarder sous...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>

--- a/src/plugins/rename/rename.pl.ts
+++ b/src/plugins/rename/rename.pl.ts
@@ -254,76 +254,76 @@
         <translation>Edytuj lub zmień nazwe plików i folderów piosenek</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Opis</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>P&amp;odpowiedź</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Ikona</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation>Puchar</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Grupa</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Zadanie Priorytetowe</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Cel</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>Cel wskazuje na obiekt którego nazwa zostanie zmieniona.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Schemat</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Zapisz Jako...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>

--- a/src/plugins/rename/rename.pt.ts
+++ b/src/plugins/rename/rename.pt.ts
@@ -250,76 +250,76 @@
         <translation>Editar Tarefa Renomear</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="122"/>
-        <location filename="../shared/QUTaskDialog.ui" line="397"/>
+        <location filename="../shared/QUTaskDialog.ui" line="131"/>
         <location filename="../shared/QUTaskDialog.ui" line="411"/>
-        <location filename="../shared/QUTaskDialog.ui" line="489"/>
-        <location filename="../shared/QUTaskDialog.ui" line="515"/>
+        <location filename="../shared/QUTaskDialog.ui" line="425"/>
+        <location filename="../shared/QUTaskDialog.ui" line="503"/>
+        <location filename="../shared/QUTaskDialog.ui" line="529"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="158"/>
+        <location filename="../shared/QUTaskDialog.ui" line="176"/>
         <source>&amp;Description</source>
         <translation>&amp;Descrição</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="171"/>
+        <location filename="../shared/QUTaskDialog.ui" line="189"/>
         <source>T&amp;oolTip</source>
         <translation>&amp;Ferramentas</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="209"/>
+        <location filename="../shared/QUTaskDialog.ui" line="224"/>
         <source>&amp;Icon</source>
         <translation>&amp;Icon</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="228"/>
+        <location filename="../shared/QUTaskDialog.ui" line="243"/>
         <source>Cup</source>
         <translation>Taça</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="256"/>
+        <location filename="../shared/QUTaskDialog.ui" line="270"/>
         <source>&amp;Group</source>
         <translation>&amp;Grupo</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="281"/>
+        <location filename="../shared/QUTaskDialog.ui" line="295"/>
         <source>Exclusive task</source>
         <translation>Tarefa exclusiva</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="311"/>
+        <location filename="../shared/QUTaskDialog.ui" line="325"/>
         <source>&amp;Target</source>
         <translation>&amp;Target</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="329"/>
+        <location filename="../shared/QUTaskDialog.ui" line="343"/>
         <source>The target specifies the object on which the renaming will be done.</source>
         <translation>A target especifica o objecto no qual a mudança de nome será feito.</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="333"/>
+        <location filename="../shared/QUTaskDialog.ui" line="347"/>
         <source>mp3</source>
         <translation>mp3</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="363"/>
+        <location filename="../shared/QUTaskDialog.ui" line="377"/>
         <source>&amp;Schema</source>
         <translation>&amp;Esquema</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="563"/>
+        <location filename="../shared/QUTaskDialog.ui" line="586"/>
         <source>Save As...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="590"/>
+        <location filename="../shared/QUTaskDialog.ui" line="613"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../shared/QUTaskDialog.ui" line="601"/>
+        <location filename="../shared/QUTaskDialog.ui" line="624"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>

--- a/src/preferences/QUPathsDialog.cpp
+++ b/src/preferences/QUPathsDialog.cpp
@@ -16,26 +16,16 @@ QUPathsDialog::QUPathsDialog(bool firstTimeSetup, QWidget *parent): QDialog(pare
 	connect(acceptBtn, SIGNAL(clicked()), this, SLOT(accept()));
 	connect(rejectBtn, SIGNAL(clicked()), this, SLOT(reject()));
 
-	connect(pathEditUs, SIGNAL(textChanged(QString)), this, SLOT(checkUsPath()));
 	connect(pathEditPlaylist, SIGNAL(textChanged(QString)), this, SLOT(checkPlaylistPath()));
-	connect(pathEditCover, SIGNAL(textChanged(QString)), this, SLOT(checkCoverPath()));
-	connect(pathEditLang, SIGNAL(textChanged(QString)), this, SLOT(checkLanguagePath()));
 	connect(songPathList, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(checkSongPath(QListWidgetItem*)));
 
-	connect(browseUsBtn, SIGNAL(clicked()), this, SLOT(chooseUsPath()));
 	connect(browsePlaylistBtn, SIGNAL(clicked()), this, SLOT(choosePlaylistPath()));
-	connect(browseCoverBtn, SIGNAL(clicked()), this, SLOT(chooseCoverPath()));
-	connect(browseLangBtn, SIGNAL(clicked()), this, SLOT(chooseLanguagePath()));
 	connect(browseSongBtn, SIGNAL(clicked()), this, SLOT(chooseSongPath()));
 
 	connect(removeSongPathBtn, SIGNAL(clicked()), this, SLOT(removeSongPath()));
-	connect(autoDetectBtn, SIGNAL(clicked()), this, SLOT(autoDetectPaths()));
 
 	QSettings s;
-	pathEditUs->setText(s.value("usPath", "").toString());
 	pathEditPlaylist->setText(s.value("playlistFilePath", "").toString());
-	pathEditCover->setText(s.value("usCoverPath", "").toString());
-	pathEditLang->setText(s.value("usLangPath", "").toString());
 
 	songPathList->clear();
 	if(s.contains("songPaths"))
@@ -48,9 +38,6 @@ QUPathsDialog::QUPathsDialog(bool firstTimeSetup, QWidget *parent): QDialog(pare
 
 void QUPathsDialog::accept() {
 	QSettings s;
-	s.setValue("usPath", pathEditUs->text());
-	s.setValue("usCoverPath", pathEditCover->text());
-	s.setValue("usLangPath", pathEditLang->text());
 
 	s.setValue("playlistFilePath", pathEditPlaylist->text());
 	playlistDB->setDir(pathEditPlaylist->text());
@@ -62,31 +49,10 @@ void QUPathsDialog::accept() {
 		songPaths.append(QDir::toNativeSeparators(QU::BaseDir.path()));
 	s.setValue("songPaths", songPaths);
 
-	if(!songPaths.isEmpty() && s.value("songPath").toString().isEmpty())
+	if(!songPaths.isEmpty() && (s.value("songPath").toString().isEmpty() || !songPaths.contains(s.value("songPath").toString())))
 		s.setValue("songPath", songPaths.first());
 
 	QDialog::accept();
-}
-
-void QUPathsDialog::checkUsPath() {
-	QDir d(pathEditUs->text());
-
-	if(!d.exists()) {
-		showError(chkLblUs, tr("Path does not exist."));
-		autoDetectBtn->hide();
-	} else if(pathEditUs->text().isEmpty()) {
-		showError(chkLblUs, tr("Path is empty."));
-		autoDetectBtn->hide();
-	} else if(!hasConfigFile(d)) {
-		showProblems(chkLblUs, tr("Configuration file \"config.ini\" not found."));
-		autoDetectBtn->show();
-	} else if(!isUltraStar(d) && !isUltraStarDeluxe(d)) {
-		showProblems(chkLblUs, tr("Could not recognize UltraStar or UltraStar Deluxe."));
-		autoDetectBtn->show();
-	} else {
-		showOk(chkLblUs);
-		autoDetectBtn->show();
-	}
 }
 
 void QUPathsDialog::checkPlaylistPath() {
@@ -98,30 +64,6 @@ void QUPathsDialog::checkPlaylistPath() {
 		showError(chkLblPlaylist, tr("Path is empty."));
 	else
 		showOk(chkLblPlaylist);
-}
-
-void QUPathsDialog::checkCoverPath() {
-	QDir d(pathEditCover->text());
-
-	if(!d.exists())
-		showError(chkLblCover, tr("Path does not exist."));
-	else if(pathEditCover->text().isEmpty())
-		showError(chkLblCover, tr("Path is empty."));
-	else if(!hasCoversFile(d))
-		showProblems(chkLblCover, tr("Could not find \"covers.ini\"."));
-	else
-		showOk(chkLblCover);
-}
-
-void QUPathsDialog::checkLanguagePath() {
-	QDir d(pathEditLang->text());
-
-	if(!d.exists())
-		showError(chkLblLang, tr("Path does not exist."));
-	else if(pathEditLang->text().isEmpty())
-		showError(chkLblLang, tr("Path is empty."));
-	else
-		showOk(chkLblLang);
 }
 
 void QUPathsDialog::checkSongPath(QListWidgetItem *item) {
@@ -154,28 +96,10 @@ void QUPathsDialog::checkSongPath(QListWidgetItem *item) {
 	connect(songPathList, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(checkSongPath(QListWidgetItem*)));
 }
 
-void QUPathsDialog::chooseUsPath() {
-	QString path = QFileDialog::getExistingDirectory(this, tr("Select folder of UltraStar (Deluxe)"), pathEditUs->text());
-	if(!path.isEmpty())
-		pathEditUs->setText(QDir::toNativeSeparators(path));
-}
-
 void QUPathsDialog::choosePlaylistPath() {
 	QString path = QFileDialog::getExistingDirectory(this, tr("Select folder for playlists"), pathEditPlaylist->text());
 	if(!path.isEmpty())
 		pathEditPlaylist->setText(QDir::toNativeSeparators(path));
-}
-
-void QUPathsDialog::chooseCoverPath() {
-	QString path = QFileDialog::getExistingDirectory(this, tr("Select folder for UltraStar cover pictures"), pathEditCover->text());
-	if(!path.isEmpty())
-		pathEditCover->setText(QDir::toNativeSeparators(path));
-}
-
-void QUPathsDialog::chooseLanguagePath() {
-	QString path = QFileDialog::getExistingDirectory(this, tr("Select folder of UltraStar language files"), pathEditLang->text());
-	if(!path.isEmpty())
-		pathEditLang->setText(QDir::toNativeSeparators(path));
 }
 
 void QUPathsDialog::chooseSongPath() {
@@ -195,40 +119,6 @@ void QUPathsDialog::chooseSongPath() {
 void QUPathsDialog::removeSongPath() {
 	qDeleteAll(songPathList->selectedItems());
 	updateHelpText();
-}
-
-void QUPathsDialog::autoDetectPaths() {
-	QDir d(pathEditUs->text());
-
-	if(QFileInfo(d, "Playlists").exists())
-		pathEditPlaylist->setText(QFileInfo(d, "Playlists").filePath());
-	if(QFileInfo(d, "Covers").exists())
-		pathEditCover->setText(QFileInfo(d, "Covers").filePath());
-	if(QFileInfo(d, "Languages").exists())
-		pathEditLang->setText(QFileInfo(d, "Languages").filePath());
-	if(QFileInfo(d, "Songs").exists() && songPathList->findItems(QFileInfo(d, "Songs").filePath(), Qt::MatchFixedString).isEmpty()) {
-		QListWidgetItem *pathItem = new QListWidgetItem(QFileInfo(d, "Songs").filePath());
-		pathItem->setFlags(pathItem->flags() | Qt::ItemIsEditable);
-		songPathList->addItem(pathItem);
-		checkSongPath(pathItem);
-		updateHelpText();
-	}
-}
-
-bool QUPathsDialog::isUltraStar(const QDir &d) const {
-	return QFileInfo(d, "UltraStar.exe").exists();
-}
-
-bool QUPathsDialog::isUltraStarDeluxe(const QDir &d) const {
-	return QFileInfo(d, "USdx.exe").exists();
-}
-
-bool QUPathsDialog::hasConfigFile(const QDir &d) const {
-	return QFileInfo(d, "config.ini").exists();
-}
-
-bool QUPathsDialog::hasCoversFile(const QDir &d) const {
-	return QFileInfo(d, "covers.ini").exists();
 }
 
 void QUPathsDialog::showOk(QLabel *lbl) {
@@ -253,7 +143,7 @@ void QUPathsDialog::updateHelpText() {
 		rejectBtn->hide();
 		acceptBtn->setEnabled(songPathList->count() > 0);
 		infoIconLbl->setPixmap(QPixmap(":/marks/information.png"));
-		textLbl->setText(tr("<b>First time path setup:</b><br><br>Choose your UltraStar folder and click on the <b>magic wand</b>, which appears then, to auto-detect the other folders. You will need at least <b>one song folder</b>. If you set more than one folder for songs, the first one will be used for now."));
+		textLbl->setText(tr("<b>First time path setup:</b><br><br>Choose at least <b>one song folder</b>. If you set more than one folder for songs, the first one will be used for now. Optionally, choose a folder for <b>Playlists</b>."));
 		return;
 	}
 

--- a/src/preferences/QUPathsDialog.h
+++ b/src/preferences/QUPathsDialog.h
@@ -19,29 +19,17 @@ public slots:
 	virtual void accept();
 
 private slots:
-	void checkUsPath();
 	void checkPlaylistPath();
-	void checkCoverPath();
-	void checkLanguagePath();
 	void checkSongPath(QListWidgetItem *item);
 
-	void chooseUsPath();
 	void choosePlaylistPath();
-	void chooseCoverPath();
-	void chooseLanguagePath();
 	void chooseSongPath();
 
 	void removeSongPath();
 
-	void autoDetectPaths();
 
 private:
 	bool _firstTimeSetup;
-
-	bool isUltraStar(const QDir &d) const;
-	bool isUltraStarDeluxe(const QDir &d) const;
-	bool hasConfigFile(const QDir &d) const;
-	bool hasCoversFile(const QDir &d) const;
 
 	void showOk(QLabel *lbl);
 	void showError(QLabel *lbl, const QString &tooltip);

--- a/src/preferences/QUPathsDialog.ui
+++ b/src/preferences/QUPathsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>356</width>
-    <height>285</height>
+    <height>317</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -130,7 +130,7 @@
       <bool>true</bool>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="_2">
       <item>
@@ -148,7 +148,7 @@
          <pixmap resource="../resources/UltraStar-Manager.qrc">:/marks/information.png</pixmap>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
         </property>
        </widget>
       </item>
@@ -158,7 +158,7 @@
          <string>...</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -171,7 +171,7 @@
    <item>
     <widget class="Line" name="line_2">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -192,168 +192,15 @@
      <property name="spacing">
       <number>5</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../resources/UltraStar-Manager.qrc">:/marks/usdx.png</pixmap>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="usLbl">
-       <property name="text">
-        <string>UltraStar</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
+     <item row="2" column="2">
       <widget class="QFrame" name="frame_2">
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
        <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
+        <enum>QFrame::Shape::StyledPanel</enum>
        </property>
        <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
+        <enum>QFrame::Shadow::Raised</enum>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="spacing">
-         <number>3</number>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="chkLblUs">
-          <property name="minimumSize">
-           <size>
-            <width>20</width>
-            <height>16</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>20</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="pixmap">
-           <pixmap resource="../resources/UltraStar-Manager.qrc">:/marks/path_ok.png</pixmap>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="pathEditUs">
-          <property name="text">
-           <string>C:\UltraStar</string>
-          </property>
-          <property name="frame">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="autoDetectBtn">
-          <property name="toolTip">
-           <string>Auto-detect other folders</string>
-          </property>
-          <property name="styleSheet">
-           <string>padding: 0;
-border-width: 0;
-margin: 0;</string>
-          </property>
-          <property name="text">
-           <string>...</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../resources/UltraStar-Manager.qrc">
-            <normaloff>:/marks/wand.png</normaloff>:/marks/wand.png</iconset>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QToolButton" name="browseUsBtn">
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../resources/UltraStar-Manager.qrc">
-         <normaloff>:/control/folder_explore.png</normaloff>:/control/folder_explore.png</iconset>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../resources/UltraStar-Manager.qrc">:/control/playlist.png</pixmap>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Playlists</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QFrame" name="frame_3">
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <property name="spacing">
-         <number>3</number>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QLabel" name="chkLblPlaylist">
           <property name="minimumSize">
@@ -375,7 +222,7 @@ margin: 0;</string>
            <pixmap resource="../resources/UltraStar-Manager.qrc">:/marks/path_ok.png</pixmap>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -392,260 +239,7 @@ margin: 0;</string>
        </layout>
       </widget>
      </item>
-     <item row="1" column="3">
-      <widget class="QToolButton" name="browsePlaylistBtn">
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../resources/UltraStar-Manager.qrc">
-         <normaloff>:/control/folder_explore.png</normaloff>:/control/folder_explore.png</iconset>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_11">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../resources/UltraStar-Manager.qrc">:/types/cover.png</pixmap>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="label_9">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Covers</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QFrame" name="frame_4">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <property name="spacing">
-         <number>3</number>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="chkLblCover">
-          <property name="minimumSize">
-           <size>
-            <width>20</width>
-            <height>16</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>20</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="pixmap">
-           <pixmap resource="../resources/UltraStar-Manager.qrc">:/marks/path_ok.png</pixmap>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="pathEditCover">
-          <property name="text">
-           <string>C:\UltraStar\Covers</string>
-          </property>
-          <property name="frame">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="QToolButton" name="browseCoverBtn">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../resources/UltraStar-Manager.qrc">
-         <normaloff>:/control/folder_explore.png</normaloff>:/control/folder_explore.png</iconset>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_14">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../resources/UltraStar-Manager.qrc">:/types/language.png</pixmap>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="label_12">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Languages</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QFrame" name="frame_5">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <property name="spacing">
-         <number>3</number>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="chkLblLang">
-          <property name="minimumSize">
-           <size>
-            <width>20</width>
-            <height>16</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>20</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="pixmap">
-           <pixmap resource="../resources/UltraStar-Manager.qrc">:/marks/path_ok.png</pixmap>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="pathEditLang">
-          <property name="text">
-           <string>C:\UltraStar\Languages</string>
-          </property>
-          <property name="frame">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="3" column="3">
-      <widget class="QToolButton" name="browseLangBtn">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../resources/UltraStar-Manager.qrc">
-         <normaloff>:/control/folder_explore.png</normaloff>:/control/folder_explore.png</iconset>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../resources/UltraStar-Manager.qrc">:/control/folder_note.png</pixmap>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Songs</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
+     <item row="1" column="2">
       <widget class="QListWidget" name="songPathList">
        <property name="font">
         <font>
@@ -657,13 +251,13 @@ margin: 0;</string>
         <bool>true</bool>
        </property>
        <property name="dragDropMode">
-        <enum>QAbstractItemView::InternalMove</enum>
+        <enum>QAbstractItemView::DragDropMode::InternalMove</enum>
        </property>
        <property name="alternatingRowColors">
         <bool>false</bool>
        </property>
        <property name="selectionMode">
-        <enum>QAbstractItemView::ExtendedSelection</enum>
+        <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
        </property>
        <item>
         <property name="text">
@@ -685,7 +279,17 @@ margin: 0;</string>
        </item>
       </widget>
      </item>
-     <item row="4" column="3">
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Songs</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
       <layout class="QVBoxLayout" name="verticalLayout">
        <property name="spacing">
         <number>0</number>
@@ -707,7 +311,7 @@ margin: 0;</string>
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -733,12 +337,89 @@ margin: 0;</string>
        </item>
       </layout>
      </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../resources/UltraStar-Manager.qrc">:/control/playlist.png</pixmap>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QFrame" name="frame_4">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="autoFillBackground">
+        <bool>true</bool>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::Shape::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Shadow::Sunken</enum>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="spacing">
+         <number>3</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+       </layout>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../resources/UltraStar-Manager.qrc">:/control/folder_note.png</pixmap>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Playlists</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QToolButton" name="browsePlaylistBtn">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../resources/UltraStar-Manager.qrc">
+         <normaloff>:/control/folder_explore.png</normaloff>:/control/folder_explore.png</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -762,7 +443,7 @@ margin: 0;</string>
      <item>
       <spacer>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/src/resources/lang/UltraStar-Manager.de.ts
+++ b/src/resources/lang/UltraStar-Manager.de.ts
@@ -2937,80 +2937,72 @@ ausführen</translation>
 <context>
     <name>QUPathsDialog</name>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="75"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="96"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="107"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="120"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="137"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="62"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="79"/>
         <source>Path does not exist.</source>
         <translation>Pfad existiert nicht.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="78"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="98"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="109"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="122"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="141"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="64"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="83"/>
         <source>Path is empty.</source>
         <translation>Pfad ist leer.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="81"/>
-        <source>Configuration file &quot;config.ini&quot; not found.</source>
-        <translation>Konfigurationsdatei &quot;config.ini&quot; nicht gefunden.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="84"/>
-        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
-        <translation>Konnte UltraStar oder UltraStar Deluxe nicht erkennen.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="111"/>
-        <source>Could not find &quot;covers.ini&quot;.</source>
-        <translation>Konnte &quot;covers.ini&quot; nicht finden.</translation>
-    </message>
-    <message>
         <location filename="../../preferences/QUPathsDialog.cpp" line="146"/>
+        <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now. Optionally, choose a folder for &lt;b&gt;Playlists&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration file &quot;config.ini&quot; not found.</source>
+        <translation type="vanished">Konfigurationsdatei &quot;config.ini&quot; nicht gefunden.</translation>
+    </message>
+    <message>
+        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
+        <translation type="vanished">Konnte UltraStar oder UltraStar Deluxe nicht erkennen.</translation>
+    </message>
+    <message>
+        <source>Could not find &quot;covers.ini&quot;.</source>
+        <translation type="vanished">Konnte &quot;covers.ini&quot; nicht finden.</translation>
+    </message>
+    <message>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="88"/>
         <source>This song path is active. Songs were loaded.</source>
         <translation>Dieser Pfad ist aktiv. Songs wurden geladen.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="158"/>
         <source>Select folder of UltraStar (Deluxe)</source>
-        <translation>Wähle den Ordner von UltraStar (Deluxe)</translation>
+        <translation type="vanished">Wähle den Ordner von UltraStar (Deluxe)</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="164"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="100"/>
         <source>Select folder for playlists</source>
         <translation>Wähle Ordner für Playlisten</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="170"/>
         <source>Select folder for UltraStar cover pictures</source>
-        <translation>Wähle den Ordner für UltarStar Cover-Bilder</translation>
+        <translation type="vanished">Wähle den Ordner für UltarStar Cover-Bilder</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="176"/>
         <source>Select folder of UltraStar language files</source>
-        <translation>Wähle den Ordner für UltarStar Sprachdateien</translation>
+        <translation type="vanished">Wähle den Ordner für UltarStar Sprachdateien</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="182"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="106"/>
         <source>Choose your UltraStar song directory</source>
         <translation>Wähle deinen UltraStar-Song-Ordner</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="256"/>
         <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose your UltraStar folder and click on the &lt;b&gt;magic wand&lt;/b&gt;, which appears then, to auto-detect the other folders. You will need at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now.</source>
-        <translation>&lt;b&gt;Einmaliges Pfad-Setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Wähle deinen UltraStar-Ordner und clicke auf den &lt;b&gt;Zauberstab&lt;/b&gt;, welcher dann auftaucht, um die anderen Pfade automatisch zu erkennen. Du benötigst mindestens &lt;b&gt;einen Songordner&lt;/b&gt;. Wenn du mehr als einen Ordner für Songs festlegst, wird jetzt der erste genommen. Du kannst dies später ändern.</translation>
+        <translation type="vanished">&lt;b&gt;Einmaliges Pfad-Setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Wähle deinen UltraStar-Ordner und clicke auf den &lt;b&gt;Zauberstab&lt;/b&gt;, welcher dann auftaucht, um die anderen Pfade automatisch zu erkennen. Du benötigst mindestens &lt;b&gt;einen Songordner&lt;/b&gt;. Wenn du mehr als einen Ordner für Songs festlegst, wird jetzt der erste genommen. Du kannst dies später ändern.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="262"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="152"/>
         <source>Please choose at least &lt;b&gt;one song path&lt;/b&gt;. Otherwise the main functionality of this program will not be available.</source>
         <translation>Bitte wähle mindestens &lt;b&gt;einen Songordner&lt;/b&gt;, andernfalls ist die grundlegende Funktionalität dieser Anwendung nicht gewährleistet.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="265"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="155"/>
         <source>Set all paths so that a &lt;b&gt;green tick&lt;/b&gt; appears in front of each one. This allows all program features to work properly.</source>
         <translation>Setze alle Pfade so, dass ein &lt;b&gt;grünes Häkchen&lt;/b&gt; vor jedem auftaucht. Damit ist sichergestellt, dass die Anwendung korrekt arbeiten kann.</translation>
     </message>
@@ -3021,90 +3013,56 @@ ausführen</translation>
     </message>
     <message>
         <location filename="../../preferences/QUPathsDialog.ui" line="158"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="302"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="398"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="506"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="614"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="696"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="723"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="300"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="327"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="406"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="208"/>
-        <source>UltraStar</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="267"/>
-        <source>C:\UltraStar</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="385"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="232"/>
         <source>C:\UltraStar\Playlists</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="490"/>
-        <source>C:\UltraStar\Covers</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="598"/>
-        <source>C:\UltraStar\Languages</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="670"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="264"/>
         <source>C:\Songs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="679"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="273"/>
         <source>D:\External\Songs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="277"/>
         <source>Auto-detect other folders</source>
-        <translation>Andere Pfade automatisch erkennen</translation>
+        <translation type="vanished">Andere Pfade automatisch erkennen</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="280"/>
-        <source>padding: 0;
-border-width: 0;
-margin: 0;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="326"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="399"/>
         <source>Playlists</source>
         <translation>Playlisten</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="428"/>
         <source>Covers</source>
-        <translation>Cover</translation>
+        <translation type="vanished">Cover</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="536"/>
         <source>Languages</source>
-        <translation>Sprachen</translation>
+        <translation type="vanished">Sprachen</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="641"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
         <source>Songs</source>
         <translation>Songs</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="778"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="459"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="789"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="470"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -4428,12 +4386,12 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="185"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="194"/>
         <source>[ReplayGain Scanner] failed to write tags to audio file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="207"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="216"/>
         <source>[ReplayGain Scanner] Error occured while decoding file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4441,7 +4399,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QUReplayGainScanner</name>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="226"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="235"/>
         <source>[ReplayGain Scanner] Song &apos;%1 - %2&apos; has no valid audio file</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.es.ts
+++ b/src/resources/lang/UltraStar-Manager.es.ts
@@ -2433,80 +2433,72 @@ Tareas</translation>
 <context>
     <name>QUPathsDialog</name>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="75"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="96"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="107"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="120"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="137"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="62"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="79"/>
         <source>Path does not exist.</source>
         <translation>Ruta de acceso no existe.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="78"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="98"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="109"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="122"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="141"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="64"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="83"/>
         <source>Path is empty.</source>
         <translation>Ruta de acceso vacia.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="81"/>
-        <source>Configuration file &quot;config.ini&quot; not found.</source>
-        <translation>No se encuentra el archivo de configuración &quot;config.ini&quot;.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="84"/>
-        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
-        <translation>No se pudo reconocer UltraStar o UltraStar Deluxe.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="111"/>
-        <source>Could not find &quot;covers.ini&quot;.</source>
-        <translation>No se pudo encontrar &quot;covers.ini&quot;.</translation>
-    </message>
-    <message>
         <location filename="../../preferences/QUPathsDialog.cpp" line="146"/>
+        <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now. Optionally, choose a folder for &lt;b&gt;Playlists&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration file &quot;config.ini&quot; not found.</source>
+        <translation type="vanished">No se encuentra el archivo de configuración &quot;config.ini&quot;.</translation>
+    </message>
+    <message>
+        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
+        <translation type="vanished">No se pudo reconocer UltraStar o UltraStar Deluxe.</translation>
+    </message>
+    <message>
+        <source>Could not find &quot;covers.ini&quot;.</source>
+        <translation type="vanished">No se pudo encontrar &quot;covers.ini&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="88"/>
         <source>This song path is active. Songs were loaded.</source>
         <translation>La ruta de acceso a las canciones está activa. Se cargaron las canciones.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="158"/>
         <source>Select folder of UltraStar (Deluxe)</source>
-        <translation>Selecciona la carpeta de UltraStar (Deluxe)</translation>
+        <translation type="vanished">Selecciona la carpeta de UltraStar (Deluxe)</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="164"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="100"/>
         <source>Select folder for playlists</source>
         <translation>Selecciona la carpeta para listas de reproducción.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="170"/>
         <source>Select folder for UltraStar cover pictures</source>
-        <translation>Selecciona la carpeta de las carátulas de UltraStar.</translation>
+        <translation type="vanished">Selecciona la carpeta de las carátulas de UltraStar.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="176"/>
         <source>Select folder of UltraStar language files</source>
-        <translation>Selecciona la carpeta de los archivos de idioma de UltraStar.</translation>
+        <translation type="vanished">Selecciona la carpeta de los archivos de idioma de UltraStar.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="182"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="106"/>
         <source>Choose your UltraStar song directory</source>
         <translation>Escoge el directorio de las canciones de UltraStar.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="256"/>
         <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose your UltraStar folder and click on the &lt;b&gt;magic wand&lt;/b&gt;, which appears then, to auto-detect the other folders. You will need at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now.</source>
-        <translation>&lt;b&gt;Inicialización de ruta de acceso por primera vez:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Escoge tu carpeta de UltraStar y haz clic en la &lt;b&gt;varita mágica&lt;/b&gt;, que luego autodetectará las demás carpetas. Necesitarás al menos &lt;b&gt;una carpeta de canciones&lt;/b&gt;. Si defines más de una carpeta de canciones se usará la primera por ahora.</translation>
+        <translation type="vanished">&lt;b&gt;Inicialización de ruta de acceso por primera vez:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Escoge tu carpeta de UltraStar y haz clic en la &lt;b&gt;varita mágica&lt;/b&gt;, que luego autodetectará las demás carpetas. Necesitarás al menos &lt;b&gt;una carpeta de canciones&lt;/b&gt;. Si defines más de una carpeta de canciones se usará la primera por ahora.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="262"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="152"/>
         <source>Please choose at least &lt;b&gt;one song path&lt;/b&gt;. Otherwise the main functionality of this program will not be available.</source>
         <translation>Por favor, escoge al menos &lt;b&gt;una ruta de acceso para canciones&lt;/b&gt;. De lo contrario la funcionalidad principal de este programa no estará disponible.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="265"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="155"/>
         <source>Set all paths so that a &lt;b&gt;green tick&lt;/b&gt; appears in front of each one. This allows all program features to work properly.</source>
         <translation>Definir todas las rutas de acceso, de manera que un &lt;b&gt;tick verde&lt;/b&gt; aparezca frente a cada una. Esto permite que todas las características del programa funcionen correctamente.</translation>
     </message>
@@ -2517,92 +2509,80 @@ Tareas</translation>
     </message>
     <message>
         <location filename="../../preferences/QUPathsDialog.ui" line="158"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="302"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="398"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="506"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="614"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="696"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="723"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="300"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="327"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="406"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="208"/>
         <source>UltraStar</source>
-        <translation>UltraStar</translation>
+        <translation type="vanished">UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="267"/>
         <source>C:\UltraStar</source>
-        <translation>C:\UltraStar</translation>
+        <translation type="vanished">C:\UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="385"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="232"/>
         <source>C:\UltraStar\Playlists</source>
         <translation>C:\UltraStar\Playlists</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="490"/>
         <source>C:\UltraStar\Covers</source>
-        <translation>C:\UltraStar\Covers</translation>
+        <translation type="vanished">C:\UltraStar\Covers</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="598"/>
         <source>C:\UltraStar\Languages</source>
-        <translation>C:\UltraStar\Languages</translation>
+        <translation type="vanished">C:\UltraStar\Languages</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="670"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="264"/>
         <source>C:\Songs</source>
         <translation>C:\Songs</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="679"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="273"/>
         <source>D:\External\Songs</source>
         <translation>D:\External\Songs</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="277"/>
         <source>Auto-detect other folders</source>
-        <translation>Autodetectar las demás carpetas</translation>
+        <translation type="vanished">Autodetectar las demás carpetas</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="280"/>
         <source>padding: 0;
 border-width: 0;
 margin: 0;</source>
-        <translation>padding: 0;
+        <translation type="vanished">padding: 0;
 border-width: 0;
 margin: 0;</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="326"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="399"/>
         <source>Playlists</source>
         <translation>Listas de reproducción</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="428"/>
         <source>Covers</source>
-        <translation>Carátulas</translation>
+        <translation type="vanished">Carátulas</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="536"/>
         <source>Languages</source>
-        <translation>Idiomas</translation>
+        <translation type="vanished">Idiomas</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="641"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
         <source>Songs</source>
         <translation>Canciones</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="778"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="459"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="789"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="470"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -3786,12 +3766,12 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="185"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="194"/>
         <source>[ReplayGain Scanner] failed to write tags to audio file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="207"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="216"/>
         <source>[ReplayGain Scanner] Error occured while decoding file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3799,7 +3779,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QUReplayGainScanner</name>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="226"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="235"/>
         <source>[ReplayGain Scanner] Song &apos;%1 - %2&apos; has no valid audio file</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.fr.ts
+++ b/src/resources/lang/UltraStar-Manager.fr.ts
@@ -2529,168 +2529,130 @@ Tâches</translation>
     </message>
     <message>
         <location filename="../../preferences/QUPathsDialog.ui" line="158"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="302"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="398"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="506"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="614"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="696"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="723"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="300"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="327"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="406"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="208"/>
         <source>UltraStar</source>
-        <translation>UltraStar</translation>
+        <translation type="vanished">UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="267"/>
-        <source>C:\UltraStar</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="385"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="232"/>
         <source>C:\UltraStar\Playlists</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="490"/>
-        <source>C:\UltraStar\Covers</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="598"/>
-        <source>C:\UltraStar\Languages</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="670"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="264"/>
         <source>C:\Songs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="679"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="273"/>
         <source>D:\External\Songs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="277"/>
         <source>Auto-detect other folders</source>
-        <translation>Détecter automatiquement les autres dossiers</translation>
+        <translation type="vanished">Détecter automatiquement les autres dossiers</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="280"/>
-        <source>padding: 0;
-border-width: 0;
-margin: 0;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="326"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="399"/>
         <source>Playlists</source>
         <translation>Listes de lecture</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="428"/>
         <source>Covers</source>
-        <translation>Couvertures</translation>
+        <translation type="vanished">Couvertures</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="536"/>
         <source>Languages</source>
-        <translation>Langues</translation>
+        <translation type="vanished">Langues</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="641"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
         <source>Songs</source>
         <translation>Chansons</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="778"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="459"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="789"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="470"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="75"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="96"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="107"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="120"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="137"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="62"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="79"/>
         <source>Path does not exist.</source>
         <translation>Le dossier n&apos;existe pas.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="78"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="98"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="109"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="122"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="141"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="64"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="83"/>
         <source>Path is empty.</source>
         <translation>Le dossier est vide.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="81"/>
-        <source>Configuration file &quot;config.ini&quot; not found.</source>
-        <translation>Fichier de configuration&quot;config.ini&quot; introuvable.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="84"/>
-        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
-        <translation>Ne reconnait pas Ultrastar ou Ultrastar Deluxe.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="111"/>
-        <source>Could not find &quot;covers.ini&quot;.</source>
-        <translation>Fichier &quot;cover.ini&quot; introuvable.</translation>
-    </message>
-    <message>
         <location filename="../../preferences/QUPathsDialog.cpp" line="146"/>
+        <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now. Optionally, choose a folder for &lt;b&gt;Playlists&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration file &quot;config.ini&quot; not found.</source>
+        <translation type="vanished">Fichier de configuration&quot;config.ini&quot; introuvable.</translation>
+    </message>
+    <message>
+        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
+        <translation type="vanished">Ne reconnait pas Ultrastar ou Ultrastar Deluxe.</translation>
+    </message>
+    <message>
+        <source>Could not find &quot;covers.ini&quot;.</source>
+        <translation type="vanished">Fichier &quot;cover.ini&quot; introuvable.</translation>
+    </message>
+    <message>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="88"/>
         <source>This song path is active. Songs were loaded.</source>
         <translation>Ce dossier de chanson est actif. Les chansons ont été chargées.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="158"/>
         <source>Select folder of UltraStar (Deluxe)</source>
-        <translation>Sélectionnez le dossier d&apos;Ultrastar (Deluxe)</translation>
+        <translation type="vanished">Sélectionnez le dossier d&apos;Ultrastar (Deluxe)</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="164"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="100"/>
         <source>Select folder for playlists</source>
         <translation>Selectionnez le dossier des listes de lecture</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="170"/>
         <source>Select folder for UltraStar cover pictures</source>
-        <translation>Sélectionnez le dossier pour les images de couverture d&apos;Ultrastar</translation>
+        <translation type="vanished">Sélectionnez le dossier pour les images de couverture d&apos;Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="176"/>
         <source>Select folder of UltraStar language files</source>
-        <translation>Sélectionnez le dossier des fichiers de langue d&apos;Ultrastar</translation>
+        <translation type="vanished">Sélectionnez le dossier des fichiers de langue d&apos;Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="182"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="106"/>
         <source>Choose your UltraStar song directory</source>
         <translation>Choisissez votre fichier de chanson Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="256"/>
         <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose your UltraStar folder and click on the &lt;b&gt;magic wand&lt;/b&gt;, which appears then, to auto-detect the other folders. You will need at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now.</source>
-        <translation>&lt;b&gt;Première configuration des dossiers:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choisissez votre dossier Ultrastar et cliquez sur la &lt;b&gt;baguette magique&lt;/b&gt;, qui apparaitra afin de détecter automatiquement les autres fichiers. Vous devez avoir au moins &lt;b&gt;un dossier de chanson&lt;/b&gt;. Si vous configurez plus d&apos;un dossier de chanson, seul le premier sera utilisé pour l&apos;instant.</translation>
+        <translation type="vanished">&lt;b&gt;Première configuration des dossiers:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choisissez votre dossier Ultrastar et cliquez sur la &lt;b&gt;baguette magique&lt;/b&gt;, qui apparaitra afin de détecter automatiquement les autres fichiers. Vous devez avoir au moins &lt;b&gt;un dossier de chanson&lt;/b&gt;. Si vous configurez plus d&apos;un dossier de chanson, seul le premier sera utilisé pour l&apos;instant.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="262"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="152"/>
         <source>Please choose at least &lt;b&gt;one song path&lt;/b&gt;. Otherwise the main functionality of this program will not be available.</source>
         <translation>Merci de choisir au moins &lt;b&gt;un dossier de chanson&lt;/b&gt;. Autrement, les fonctionnalités principales de ce programme ne seront pas accessibles.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="265"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="155"/>
         <source>Set all paths so that a &lt;b&gt;green tick&lt;/b&gt; appears in front of each one. This allows all program features to work properly.</source>
         <translation>Réglez tous les dossier de façon à ce qu&apos;un &lt;b&gt;&lt;font color=&quot;green&quot;&gt;&lt;/font&gt; √ &lt;/font&gt;&lt;/b&gt; apparaisse devant chacun d&apos;eux. Cela permet à toutes les fonctionnalités du programme de fonctionner normalement.</translation>
     </message>
@@ -3910,12 +3872,12 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="185"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="194"/>
         <source>[ReplayGain Scanner] failed to write tags to audio file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="207"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="216"/>
         <source>[ReplayGain Scanner] Error occured while decoding file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3923,7 +3885,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QUReplayGainScanner</name>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="226"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="235"/>
         <source>[ReplayGain Scanner] Song &apos;%1 - %2&apos; has no valid audio file</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.pl.ts
+++ b/src/resources/lang/UltraStar-Manager.pl.ts
@@ -2809,80 +2809,72 @@ Zadania</translation>
 <context>
     <name>QUPathsDialog</name>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="75"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="96"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="107"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="120"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="137"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="62"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="79"/>
         <source>Path does not exist.</source>
         <translation>Ścieżka nie istnieje.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="78"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="98"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="109"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="122"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="141"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="64"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="83"/>
         <source>Path is empty.</source>
         <translation>Ścieżka jest pusta.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="81"/>
-        <source>Configuration file &quot;config.ini&quot; not found.</source>
-        <translation>Plik konfiguracyjny &quot;cofing.ini&quot; nie został znaleziony.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="84"/>
-        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
-        <translation>Nie można rozpoznać UltraStar lub UltraStar Deluxe.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="111"/>
-        <source>Could not find &quot;covers.ini&quot;.</source>
-        <translation>Nie można odnaleźć &quot;covers.ini&quot;.</translation>
-    </message>
-    <message>
         <location filename="../../preferences/QUPathsDialog.cpp" line="146"/>
+        <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now. Optionally, choose a folder for &lt;b&gt;Playlists&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration file &quot;config.ini&quot; not found.</source>
+        <translation type="vanished">Plik konfiguracyjny &quot;cofing.ini&quot; nie został znaleziony.</translation>
+    </message>
+    <message>
+        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
+        <translation type="vanished">Nie można rozpoznać UltraStar lub UltraStar Deluxe.</translation>
+    </message>
+    <message>
+        <source>Could not find &quot;covers.ini&quot;.</source>
+        <translation type="vanished">Nie można odnaleźć &quot;covers.ini&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="88"/>
         <source>This song path is active. Songs were loaded.</source>
         <translation>Ścieżka jest aktywna. Utwory zostały załadowane.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="158"/>
         <source>Select folder of UltraStar (Deluxe)</source>
-        <translation>Wybierz folder z UltraStar</translation>
+        <translation type="vanished">Wybierz folder z UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="164"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="100"/>
         <source>Select folder for playlists</source>
         <translation>Wybierz folder dla listy odtwarzania</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="170"/>
         <source>Select folder for UltraStar cover pictures</source>
-        <translation>Wybierz folder dla  okładek</translation>
+        <translation type="vanished">Wybierz folder dla  okładek</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="176"/>
         <source>Select folder of UltraStar language files</source>
-        <translation>Wybierz folder plików językowych UltraStar</translation>
+        <translation type="vanished">Wybierz folder plików językowych UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="182"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="106"/>
         <source>Choose your UltraStar song directory</source>
         <translation>Wybierz katalog piosenek UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="256"/>
         <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose your UltraStar folder and click on the &lt;b&gt;magic wand&lt;/b&gt;, which appears then, to auto-detect the other folders. You will need at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now.</source>
-        <translation>&lt;b&gt;Pierwsza konfiguracja ścieżki czasu:&lt;b&gt;&lt;br&gt;&lt;br&gt;Wybierz swój folder z Ultrastar oraz kliknij na &lt;b&gt;magiczną różdżke&lt;/b&gt;, która pojawi się automatycznie aby wykryć inne foldery. Będziesz potrzebował co najmniej &lt;b&gt;jednego folderu piosenki&lt;/b&gt;. Jeśli ustawisz więcej niż jeden folder piosenek, pierwszy zostanie wykorzystane teraz.</translation>
+        <translation type="vanished">&lt;b&gt;Pierwsza konfiguracja ścieżki czasu:&lt;b&gt;&lt;br&gt;&lt;br&gt;Wybierz swój folder z Ultrastar oraz kliknij na &lt;b&gt;magiczną różdżke&lt;/b&gt;, która pojawi się automatycznie aby wykryć inne foldery. Będziesz potrzebował co najmniej &lt;b&gt;jednego folderu piosenki&lt;/b&gt;. Jeśli ustawisz więcej niż jeden folder piosenek, pierwszy zostanie wykorzystane teraz.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="262"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="152"/>
         <source>Please choose at least &lt;b&gt;one song path&lt;/b&gt;. Otherwise the main functionality of this program will not be available.</source>
         <translation>Proszę wybrać co najmniej jedną ścieżkę &lt;b&gt; piosenki&lt;/b&gt;. W przeciwnym razie główna funkcjonalność tego programu nie będzie dostępna.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="265"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="155"/>
         <source>Set all paths so that a &lt;b&gt;green tick&lt;/b&gt; appears in front of each one. This allows all program features to work properly.</source>
         <translation>Ustaw wszystkie ścieżki piosenek tak aby &lt;b&gt;zielony ptaszek&lt;/b&gt; pojawił się przed każdej z nich. Dzięki temu wszystkie funkcje programu będą dostępne do poprawnej pracy.</translation>
     </message>
@@ -2893,92 +2885,80 @@ Zadania</translation>
     </message>
     <message>
         <location filename="../../preferences/QUPathsDialog.ui" line="158"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="302"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="398"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="506"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="614"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="696"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="723"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="300"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="327"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="406"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="208"/>
         <source>UltraStar</source>
-        <translation>UltraStar</translation>
+        <translation type="vanished">UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="267"/>
         <source>C:\UltraStar</source>
-        <translation>C:\UltraStar</translation>
+        <translation type="vanished">C:\UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="385"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="232"/>
         <source>C:\UltraStar\Playlists</source>
         <translation>C:\UltraStar\Playlists</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="490"/>
         <source>C:\UltraStar\Covers</source>
-        <translation>C:\UltraStar\Covers</translation>
+        <translation type="vanished">C:\UltraStar\Covers</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="598"/>
         <source>C:\UltraStar\Languages</source>
-        <translation>C:\UltraStar\Languages</translation>
+        <translation type="vanished">C:\UltraStar\Languages</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="670"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="264"/>
         <source>C:\Songs</source>
         <translation>C:\Songs</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="679"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="273"/>
         <source>D:\External\Songs</source>
         <translation>D:\External\Songs</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="277"/>
         <source>Auto-detect other folders</source>
-        <translation>Autodetekcja innych folderów</translation>
+        <translation type="vanished">Autodetekcja innych folderów</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="280"/>
         <source>padding: 0;
 border-width: 0;
 margin: 0;</source>
-        <translation>padding: 0;
+        <translation type="vanished">padding: 0;
 border-width: 0;
 margin: 0;</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="326"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="399"/>
         <source>Playlists</source>
         <translation>Listy odtwarzania</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="428"/>
         <source>Covers</source>
-        <translation>Okładki</translation>
+        <translation type="vanished">Okładki</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="536"/>
         <source>Languages</source>
-        <translation>Języki</translation>
+        <translation type="vanished">Języki</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="641"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
         <source>Songs</source>
         <translation>Piosenki</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="778"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="459"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="789"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="470"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
@@ -4278,12 +4258,12 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="185"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="194"/>
         <source>[ReplayGain Scanner] failed to write tags to audio file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="207"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="216"/>
         <source>[ReplayGain Scanner] Error occured while decoding file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4291,7 +4271,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QUReplayGainScanner</name>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="226"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="235"/>
         <source>[ReplayGain Scanner] Song &apos;%1 - %2&apos; has no valid audio file</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/resources/lang/UltraStar-Manager.pt.ts
+++ b/src/resources/lang/UltraStar-Manager.pt.ts
@@ -2459,48 +2459,40 @@ Tarefas</translation>
     </message>
     <message>
         <location filename="../../preferences/QUPathsDialog.ui" line="158"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="302"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="398"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="506"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="614"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="696"/>
-        <location filename="../../preferences/QUPathsDialog.ui" line="723"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="300"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="327"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="406"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="208"/>
         <source>UltraStar</source>
-        <translation>Ultrastar</translation>
+        <translation type="vanished">Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="267"/>
         <source>C:\UltraStar</source>
-        <translation>C:\UltraStar</translation>
+        <translation type="vanished">C:\UltraStar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="385"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="232"/>
         <source>C:\UltraStar\Playlists</source>
         <translation>C:\UltraStar\Playlists</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="490"/>
         <source>C:\UltraStar\Covers</source>
-        <translation>C:\UltraStar\Covers</translation>
+        <translation type="vanished">C:\UltraStar\Covers</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="598"/>
         <source>C:\UltraStar\Languages</source>
-        <translation>C:\UltraStar\Languages</translation>
+        <translation type="vanished">C:\UltraStar\Languages</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="670"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="264"/>
         <source>C:\Songs</source>
         <translation>C:\Songs</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="679"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="273"/>
         <source>D:\External\Songs</source>
         <translation>D:\External\Songs</translation>
     </message>
@@ -2509,21 +2501,19 @@ Tarefas</translation>
         <translation type="obsolete">C:/Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="277"/>
         <source>Auto-detect other folders</source>
-        <translation>Auto detectar outros directórios</translation>
+        <translation type="vanished">Auto detectar outros directórios</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="280"/>
         <source>padding: 0;
 border-width: 0;
 margin: 0;</source>
-        <translation>padding: 0;
+        <translation type="vanished">padding: 0;
 border-width: 0;
 margin: 0;</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="326"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="399"/>
         <source>Playlists</source>
         <translation>Playlists</translation>
     </message>
@@ -2532,25 +2522,23 @@ margin: 0;</translation>
         <translation type="obsolete">C:/UltraStar/Playlists</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="428"/>
         <source>Covers</source>
-        <translation>Capas</translation>
+        <translation type="vanished">Capas</translation>
     </message>
     <message>
         <source>C:/UltraStar/Covers</source>
         <translation type="obsolete">C:/UltraStar/Covers</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="536"/>
         <source>Languages</source>
-        <translation>Idiomas</translation>
+        <translation type="vanished">Idiomas</translation>
     </message>
     <message>
         <source>C:/UltraStar/Languages</source>
         <translation type="obsolete">C:/UltraStar/Languages</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="641"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="285"/>
         <source>Songs</source>
         <translation>Canções</translation>
     </message>
@@ -2563,90 +2551,82 @@ margin: 0;</translation>
         <translation type="obsolete">D:/Blubb/Songs</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="778"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="459"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.ui" line="789"/>
+        <location filename="../../preferences/QUPathsDialog.ui" line="470"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="75"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="96"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="107"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="120"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="137"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="62"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="79"/>
         <source>Path does not exist.</source>
         <translation>O caminho não existe.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="78"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="98"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="109"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="122"/>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="141"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="64"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="83"/>
         <source>Path is empty.</source>
         <translation>O caminho está vazio.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="81"/>
-        <source>Configuration file &quot;config.ini&quot; not found.</source>
-        <translation>Ficheiro de configuração &quot;config.ini&quot; não encontrado.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="84"/>
-        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
-        <translation>Não foi possível reconhecer Ultrastar ou Ultrastar Deluxe.</translation>
-    </message>
-    <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="111"/>
-        <source>Could not find &quot;covers.ini&quot;.</source>
-        <translation>Não foi possível encontrar &quot;covers.ini&quot;.</translation>
-    </message>
-    <message>
         <location filename="../../preferences/QUPathsDialog.cpp" line="146"/>
+        <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now. Optionally, choose a folder for &lt;b&gt;Playlists&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration file &quot;config.ini&quot; not found.</source>
+        <translation type="vanished">Ficheiro de configuração &quot;config.ini&quot; não encontrado.</translation>
+    </message>
+    <message>
+        <source>Could not recognize UltraStar or UltraStar Deluxe.</source>
+        <translation type="vanished">Não foi possível reconhecer Ultrastar ou Ultrastar Deluxe.</translation>
+    </message>
+    <message>
+        <source>Could not find &quot;covers.ini&quot;.</source>
+        <translation type="vanished">Não foi possível encontrar &quot;covers.ini&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="88"/>
         <source>This song path is active. Songs were loaded.</source>
         <translation>Este caminho de canções está activo. Canções foram carregadas.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="158"/>
         <source>Select folder of UltraStar (Deluxe)</source>
-        <translation>Seleccionar directório do Ultrastar (Deluxe)</translation>
+        <translation type="vanished">Seleccionar directório do Ultrastar (Deluxe)</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="164"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="100"/>
         <source>Select folder for playlists</source>
         <translation>Selecciona directório para playlists</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="170"/>
         <source>Select folder for UltraStar cover pictures</source>
-        <translation>Seleccionar directório das capas do Ultrastar</translation>
+        <translation type="vanished">Seleccionar directório das capas do Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="176"/>
         <source>Select folder of UltraStar language files</source>
-        <translation>Seleccionar directório dos ficheiros de idioma do Ultrastar</translation>
+        <translation type="vanished">Seleccionar directório dos ficheiros de idioma do Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="182"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="106"/>
         <source>Choose your UltraStar song directory</source>
         <translation>Escolha o directório de canções do Ultrastar</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="256"/>
         <source>&lt;b&gt;First time path setup:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Choose your UltraStar folder and click on the &lt;b&gt;magic wand&lt;/b&gt;, which appears then, to auto-detect the other folders. You will need at least &lt;b&gt;one song folder&lt;/b&gt;. If you set more than one folder for songs, the first one will be used for now.</source>
-        <translation>&lt;b&gt;Ultrastar Manager iniciado pera primeira vez. Configuração:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Escolha a pasta UltraStar e clique na &lt;b&gt;varinha mágica&lt;/b&gt; para detectar automaticamente as outras pastas. Você vai precisar de pelo menos uma &lt;b&gt;pasta de canções&lt;/b&gt;. Se você definir mais de uma pasta de canções, a primeira será usada inicialmente.</translation>
+        <translation type="vanished">&lt;b&gt;Ultrastar Manager iniciado pera primeira vez. Configuração:&lt;/b&gt;&lt;br&gt;&lt;br&gt;Escolha a pasta UltraStar e clique na &lt;b&gt;varinha mágica&lt;/b&gt; para detectar automaticamente as outras pastas. Você vai precisar de pelo menos uma &lt;b&gt;pasta de canções&lt;/b&gt;. Se você definir mais de uma pasta de canções, a primeira será usada inicialmente.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="262"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="152"/>
         <source>Please choose at least &lt;b&gt;one song path&lt;/b&gt;. Otherwise the main functionality of this program will not be available.</source>
         <translation>Por favor, escolha pelo menos &lt;b&gt;um caminho de canções&lt;/b&gt;. Caso contrário, a principal funcionalidade deste programa não estará disponível.</translation>
     </message>
     <message>
-        <location filename="../../preferences/QUPathsDialog.cpp" line="265"/>
+        <location filename="../../preferences/QUPathsDialog.cpp" line="155"/>
         <source>Set all paths so that a &lt;b&gt;green tick&lt;/b&gt; appears in front of each one. This allows all program features to work properly.</source>
         <translation>Defina todos os caminhos para que um &lt;b&gt;visto verde&lt;/b&gt; apareça na frente de cada um. Isso permite que todos os recursos do programa possam funcionar correctamente.</translation>
     </message>
@@ -3834,12 +3814,12 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="185"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="194"/>
         <source>[ReplayGain Scanner] failed to write tags to audio file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="207"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="216"/>
         <source>[ReplayGain Scanner] Error occured while decoding file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3847,7 +3827,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QUReplayGainScanner</name>
     <message>
-        <location filename="../../support/QUReplayGainScanner.cpp" line="226"/>
+        <location filename="../../support/QUReplayGainScanner.cpp" line="235"/>
         <source>[ReplayGain Scanner] Song &apos;%1 - %2&apos; has no valid audio file</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
The initial path setup screen has issues, as reported by various users:
- #49
- https://discord.com/channels/1048892118732656731/1169989508763234314/1405025422957088909

It asks the user to select an "UltraStar folder" which is where the UltraStar executable is located on Windows. This doesn't work at all for Mac or Linux. But even on Windows it doesn't really work in most cases, because it tries to find the files `UltraStar.exe` and `USdx.exe`, neither of which are used by any of the modern games. 

After the user selects the UltraStar folder, the program attempts to autodetect subfolders for covers, languages, and playlists. The settings for covers and languages paths are used nowhere in the code of this program. I'm guessing this was something that was planned, but never actually implemented.

The "UltraStar folder" is also not used anywhere in the code, besides for the purpose of autodetecting the 3 subfolders. Two of those subfolders are unused, as mentioned above, so the selection of an UltraStar folder does not save the user any time/effort. Therefore, this PR removes the unneeded path selections for UltraStar folder, covers, and languages. Only song paths and playlist path remain.

Because the song path is required and the playlist path is optional, the order was reversed in the dialog so that song path appears first, and playlists second.

#### Before
<img width="469" height="495" alt="Before" src="https://github.com/user-attachments/assets/0ddfdc51-60f1-4c9e-ad09-1429daa28a05" />

#### After 
<img width="469" height="457" alt="After" src="https://github.com/user-attachments/assets/2331a83d-9e0d-41a9-a3cb-207ec32a4565" />

Fixes #49 