### PR TITLE
Fix Linux Desktop File

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -220,7 +220,7 @@ jobs:
           chmod a+x linuxdeployqt*.AppImage
           cp ../../setup/unix/UltraStar-Manager.desktop .
           cp ../../setup/unix/UltraStar-Manager.png .
-          sed -i "s/Name=UltraStar-Manager/Name=LINUX-UltraStar-Manager/g" UltraStar-Manager.desktop
+          sed -i "s/Name=UltraStar Manager/Name=LINUX-UltraStar-Manager/g" UltraStar-Manager.desktop
           ./linuxdeployqt*.AppImage UltraStar-Manager.desktop -bundle-non-qt-libs -appimage
           mv LINUX-UltraStar-Manager-*.AppImage LINUX-UltraStar-Manager.AppImage
       - name: Upload AppImage Artifact

--- a/setup/unix/UltraStar-Manager.desktop
+++ b/setup/unix/UltraStar-Manager.desktop
@@ -1,9 +1,7 @@
 [Desktop Entry]
 Type=Application
-Name=UltraStar-Manager
+Name=UltraStar Manager
 Exec=UltraStar-Manager %F
 Icon=UltraStar-Manager
 Comment=Manage your UltraStar song collection with ease.
-Terminal=true
 Categories=Qt;Game;Music;X-Karaoke;X-UltraStar;
-Name[en]=UltraStar-Manager.desktop


### PR DESCRIPTION
There are a couple issues with the Linux desktop integration due to the .desktop file:
- It displays in the application launcher as `UltraStar-Manager.desktop` instead of `UltraStar Manager`
- Launching the application also launches a terminal window, which is unnecessary.

This PR fixes the issues.