### PR TITLE
Fix ReplayGain Scanner on MacOS

### DIFF
--- a/src/support/QUReplayGainScanner.cpp
+++ b/src/support/QUReplayGainScanner.cpp
@@ -88,7 +88,7 @@ bool QUReplayGainFile::scan()
 
     // Scan the file
     _decoder.start();
-    while(_decoder.isDecoding() && !_error && !_cancelled)
+    if (!(_error || _cancelled))
         _loop.exec();
     if (_error || _cancelled)
         return false;


### PR DESCRIPTION
`_decoder.isDecoding()` is returning false on macOS, probably due to a platform-specific timing tissue. It was never actually needed, so just remove it.