### PR TITLE
Sort Text Columns Case Insensitively

### DIFF
--- a/src/songtree/QUSongItem.cpp
+++ b/src/songtree/QUSongItem.cpp
@@ -626,7 +626,7 @@ bool QUSongItem::operator< (const QTreeWidgetItem &other) const {
 	case RAP_NOTES_COLUMN:
 		return this->data(column, Qt::UserRole).toDouble() < other.data(column, Qt::UserRole).toDouble(); // break;
 	default:
-		return text(column) < other.text(column);
+		return QString::compare(text(column), other.text(column), Qt::CaseInsensitive) < 0;
 	}
 }
 


### PR DESCRIPTION
Some artists intentionally stylize their name with lower case letters. The Manager current sorts these case *sensitively*, so artists names that begin with lower case letters will appear after those that start with upper case `Z`, which is not intuitive for users.

This changes the Manager to use case *insensitive* alphabetical sorting for the text columns. 