### PR TITLE
Bump Version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # UltraStar Manager Changelog
 
+## Changelog (2.3.1 to 2.4.0)
+### Features
+- Full Support for `#VOCALS` and `#INSTRUMENTAL`:
+  - Add columns in the song tree which indicates with a tick/cross whether the song has #INSTRUMENTAL and #VOCALS assigned
+  - Ability to assign #INSTRUMENTAL and #VOCALS to a song by doubling clicking on audio files in the song tree
+  - Added Rename tasks to rename the instrumental and vocals file names to include the recommended [INSTR] and [VOC] suffixes
+  - For the ReplayGain scanner feature, write the same gain from the main audio file to the instrumental and vocals files if present
+- Ability to hide file check columns
+- Sort text columns case insensitively
+- More verbose error reporting when saving a .txt fails
+
 ## Changelog (2.3.0 to 2.3.1)
 ### Bug fixes
 - Fix formatting of report dialog

--- a/setup/win64/UltraStar-Manager.nsi
+++ b/setup/win64/UltraStar-Manager.nsi
@@ -2,7 +2,7 @@ Unicode True
 XPStyle on
 
 !define PRODUCTNAME "UltraStar-Manager"
-!define PRODUCTVERSION "2.3.1"
+!define PRODUCTVERSION "2.4.0"
 Name "${PRODUCTNAME} ${PRODUCTVERSION}"
 
 !include "MUI.nsh"

--- a/src/song/QUSongFile.cpp
+++ b/src/song/QUSongFile.cpp
@@ -761,7 +761,7 @@ bool QUSongFile::save(bool force) {
 	_file.setFileName(_fi.filePath());
 
 	if(!_file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-		logSrv->add(QString(tr("Save error! The song file \"%1\" was NOT saved.")).arg(this->songFileInfo().fileName()), QU::Warning);
+		logSrv->add(QString(tr("Save error: %1! The song file \"%2\" was NOT saved.")).arg(_file.errorString()).arg(this->songFileInfo().fileName()), QU::Warning);
 		monty->watcher()->addPath(_fi.filePath());
 		return false;
 	}


### PR DESCRIPTION
This bumps the version to 2.4.0. Also, there is a user in the Discord that is having an issue where the .txt files won't save, so I added more verbose error logging by forwarding the Qt-provided error message to the event log.